### PR TITLE
vr: WindowGroup data model + registry (#3 scaffold)

### DIFF
--- a/src/plugins/vr/CMakeLists.txt
+++ b/src/plugins/vr/CMakeLists.txt
@@ -30,6 +30,7 @@ find_package(KF6 REQUIRED COMPONENTS Config CoreAddons I18n WindowSystem GlobalA
 find_package(KDecoration3 REQUIRED)
 
 set_source_files_properties(qml/Logger.qml PROPERTIES QT_QML_SINGLETON_TYPE TRUE)
+set_source_files_properties(qml/WindowGroupRegistry.qml PROPERTIES QT_QML_SINGLETON_TYPE TRUE)
 
 qt6_add_qml_module(vr
     NO_PLUGIN
@@ -83,6 +84,9 @@ qt6_add_qml_module(vr
         qml/KwinShadowModel.qml
 
         qml/TransformGizmo3D.qml
+
+        qml/WindowGroup.qml
+        qml/WindowGroupRegistry.qml
 
     SOURCES
         main.cpp

--- a/src/plugins/vr/qml/WindowGroup.qml
+++ b/src/plugins/vr/qml/WindowGroup.qml
@@ -1,0 +1,63 @@
+/*
+    SPDX-FileCopyrightText: 2026 Bake-Ware
+
+    SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+import QtQuick
+import QtQuick3D
+
+// Lateral set of windows. No parent-child window relation.
+// Members are siblings; each window orients independently.
+// Anchor = centroid of members. Thumbtack (future) = group's grab handle.
+Node {
+    id: root
+
+    enum Mode { Pinned, Stacked, Camera }
+
+    property string groupId: ""
+    property string label: ""
+    property int mode: WindowGroup.Mode.Pinned
+
+    // Members: array of Node refs (KwinApplicationWindow / mirror / etc).
+    // Lateral — windows do not become children of this Node.
+    property var members: []
+
+    // Read-only anchor in scene space (centroid of member scenePositions).
+    // Recomputed on demand; no per-frame binding (data-only scaffold).
+    function recomputeAnchor() {
+        if (!members || members.length === 0)
+            return
+        let sx = 0, sy = 0, sz = 0, n = 0
+        for (let i = 0; i < members.length; ++i) {
+            const m = members[i]
+            if (!m || !m.scenePosition) continue
+            sx += m.scenePosition.x
+            sy += m.scenePosition.y
+            sz += m.scenePosition.z
+            n += 1
+        }
+        if (n === 0) return
+        position = Qt.vector3d(sx / n, sy / n, sz / n)
+    }
+
+    function addMember(node) {
+        if (!node) return
+        if (members.indexOf(node) !== -1) return
+        const next = members.slice()
+        next.push(node)
+        members = next
+    }
+
+    function removeMember(node) {
+        const idx = members.indexOf(node)
+        if (idx === -1) return
+        const next = members.slice()
+        next.splice(idx, 1)
+        members = next
+    }
+
+    function hasMember(node) {
+        return members.indexOf(node) !== -1
+    }
+}

--- a/src/plugins/vr/qml/WindowGroupRegistry.qml
+++ b/src/plugins/vr/qml/WindowGroupRegistry.qml
@@ -1,0 +1,65 @@
+/*
+    SPDX-FileCopyrightText: 2026 Bake-Ware
+
+    SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+pragma Singleton
+import QtQuick
+
+// Global registry of WindowGroup instances.
+// Data-only scaffold (#3) — register/unregister + lookup. No persistence yet.
+QtObject {
+    id: root
+
+    // Array of WindowGroup refs. Replaced wholesale on change so bindings fire.
+    property var groups: []
+
+    signal groupRegistered(var group)
+    signal groupUnregistered(string groupId)
+
+    function _newId() {
+        return "wg_" + Date.now().toString(36) + "_" + Math.floor(Math.random() * 1e6).toString(36)
+    }
+
+    function registerGroup(group) {
+        if (!group) return null
+        if (!group.groupId || group.groupId === "")
+            group.groupId = _newId()
+        if (findById(group.groupId)) return group
+        const next = groups.slice()
+        next.push(group)
+        groups = next
+        groupRegistered(group)
+        return group
+    }
+
+    function unregisterGroup(groupId) {
+        const idx = _indexOf(groupId)
+        if (idx === -1) return
+        const next = groups.slice()
+        next.splice(idx, 1)
+        groups = next
+        groupUnregistered(groupId)
+    }
+
+    function findById(groupId) {
+        const idx = _indexOf(groupId)
+        return idx === -1 ? null : groups[idx]
+    }
+
+    function findContaining(node) {
+        for (let i = 0; i < groups.length; ++i) {
+            if (groups[i] && groups[i].hasMember(node))
+                return groups[i]
+        }
+        return null
+    }
+
+    function _indexOf(groupId) {
+        for (let i = 0; i < groups.length; ++i) {
+            if (groups[i] && groups[i].groupId === groupId) return i
+        }
+        return -1
+    }
+}

--- a/src/plugins/vr/qml/XrScene.qml
+++ b/src/plugins/vr/qml/XrScene.qml
@@ -577,6 +577,11 @@ XrView {
                     items.push({ label: qsTr("Transform"), action: "transform" })
                 if (xrView.selectedNode)
                     items.push({ label: qsTr("Done"), action: "confirmGizmo" })
+                // #3 stubs — wiring only, no behavior. Real grouping lands in #4–#7.
+                if (xrView.radialMenuTargetNode)
+                    items.push({ label: qsTr("Group"), action: "groupStub" })
+                if (xrView.radialMenuTargetNode && WindowGroupRegistry.findContaining(xrView.radialMenuTargetNode))
+                    items.push({ label: qsTr("Ungroup"), action: "ungroupStub" })
                 return items.concat([
                     { label: qsTr("Park Ray"),  action: "parkRay" },
                     { label: qsTr("Recenter"),  action: "recenter" },
@@ -593,6 +598,12 @@ XrView {
                                        radialMenuLoader.active = false
                                    } else if (action === "confirmGizmo") {
                                        xrView.selectedNode = null
+                                       radialMenuLoader.active = false
+                                   } else if (action === "groupStub") {
+                                       console.log(Logger.kwinvr, "WindowGroup: TODO create group for", xrView.radialMenuTargetNode)
+                                       radialMenuLoader.active = false
+                                   } else if (action === "ungroupStub") {
+                                       console.log(Logger.kwinvr, "WindowGroup: TODO ungroup", xrView.radialMenuTargetNode)
                                        radialMenuLoader.active = false
                                    } else if (action === "parkRay") {
                                        pickRay.enabled = false
@@ -909,6 +920,19 @@ XrView {
                             }
                         }
                     ]
+                }
+            }
+
+            // Window groups (#3 scaffold). Data-only — empty delegate.
+            // Modes (Pinned/Stacked/Camera) and thumbtack geometry land in #4–#6.
+            Repeater3D {
+                id: windowGroupRepeater
+                model: WindowGroupRegistry.groups
+                delegate: Node {
+                    required property var modelData
+                    Component.onCompleted: {
+                        if (modelData) modelData.parent = windowGroupRepeater
+                    }
                 }
             }
 


### PR DESCRIPTION
Pivot commit 2 of 7 ([#1](https://github.com/Bake-Ware/kwin-vr/issues/1)). Data model only — no behavior. Modes, thumbtack, and lasso land in #4–#7.

## What

- `WindowGroup.qml` — `Node` with `groupId`, `members[]`, `mode` enum (`Pinned`/`Stacked`/`Camera`), centroid anchor. Lateral set: members are siblings, not children. `addMember` / `removeMember` / `hasMember` / `recomputeAnchor` helpers.
- `WindowGroupRegistry.qml` (singleton) — `groups[]`, `registerGroup` / `unregisterGroup` / `findById` / `findContaining`. Auto-mints `wg_<ts>_<rand>` ids.
- `XrScene` — `Repeater3D` over `WindowGroupRegistry.groups` (empty delegate, parents the group `Node` under `allWindowsGrabHandle` so anchors land in scene space).
- Radial menu — `Group` (when target node) / `Ungroup` (when target node is in a group). Both log + close. Wiring only.

## What's not here

- Group creation flow (radial → group). Lands with #7 (lasso) — single-window groups aren't useful.
- Pinned/Stacked/Camera mode behaviors. Land in #4 / #5 / #6.
- Thumbtack geometry + grab handle. With #4.
- Persistence (kconf JSON, restore by binary/wm_class). Deferred — tied to mode behaviors.

## Design override

Lateral set, NOT tree (overrides original #3 wording). See [#3 comment](https://github.com/Bake-Ware/kwin-vr/issues/3#issuecomment-) and the [Pivot wiki](https://github.com/Bake-Ware/kwin-vr/wiki/Pivot-Windows-as-Surfaces#group-model--lateral). Wayland transients keep their parent chain; group membership is a separate set.

## Build / install

```
cmake --build build --target vr
cmake --install build/src/plugins/vr
```

Plugin loads. Radial menu shows Group entry when a node is targeted.

Closes #3

## Test plan

- [ ] Plugin loads (no QML errors in journalctl)
- [ ] Radial menu still opens
- [ ] `Group` entry appears when targeting a node; click logs `WindowGroup: TODO create group for ...` and closes menu
- [ ] No `Ungroup` entry yet (registry empty until #4 wires creation)
- [ ] Regression guards (auto-float, focus pull/pan, world grab, pseudomirror un/re-register) still pass