### PR TITLE
vr: keep stacks rigid after commit — size + pose follow the root (#18)

### DIFF
--- a/doc/TEST_BASELINE.md
+++ b/doc/TEST_BASELINE.md
@@ -78,6 +78,7 @@ kernel module and no live session. If they still fail, bisect against
 | `kwinvr-testFlatBoot` | No RHI scene graph (CI container has no `/dev/dri` → software compositing → "Qt Quick 3D is not functional") | Frame-render assertion SKIPs on that exact log marker only; boot/DBus/QML-error asserts still apply. Hard assertion anywhere GL exists. Tracked in #38. |
 | `kwinvr-testFlatReplay` | Qt 6 `qml` runtime missing | Wayland-client placement section SKIPs (a Qt 5 `qml` in PATH is rejected — it loads nothing on versionless imports); interaction asserts still apply. |
 | `kwinvr-testFlatHudReplay` | Qt 6 `qml` runtime missing, or `org.kde.layershell` QML module not installed (layer-shell-qt) | Whole test SKIPs — it has no client-free section; the #17 lift math stays pinned by `kwinvr-testQmlLogic` regardless. |
+| `kwinvr-testFlatSnapReplay` | Qt 6 `qml` runtime missing | Whole test SKIPs — it is built around two real Wayland clients. |
 
 ## Reproduce
 

--- a/doc/VOCABULARY.md
+++ b/doc/VOCABULARY.md
@@ -322,7 +322,7 @@ retest, so commit-path behaviors are at best WIP.
 - Input source(s): mouse (release of drag)
 - Config keys: `zSurfaceMarginTop (1.0 cm)`
 - Code: src/plugins/vr/qml/WindowSnapManager.qml:216-222,343-374
-- Status: WIP — same commit-path uncertainty as VOC-SNAP-050.
+- Status: Working — `_commitSnap` verified live on the flat substrate (kwinvr-testFlatSnapReplay); the release-trigger path (`_grabWatcher` firing at real drag end) still has the VOC-SNAP-050 uncertainty.
 
 ### VOC-SNAP-070: First snap snapshots original size
 **Given** a window that has never been snapped **When** a snap/stack commits **Then** its pre-snap frame size is stored in `preSnapGeom`.
@@ -379,6 +379,13 @@ retest, so commit-path behaviors are at best WIP.
 - Config keys: none
 - Code: src/plugins/vr/qml/KwinTransientWindow.qml:35-37, src/plugins/vr/qml/XrScene.qml:568
 - Status: Buggy — declared interaction with no emitter; either emit on `client.active` or remove.
+
+### VOC-SNAP-150: A stack stays one rigid container after commit
+**Given** a committed stack **Then** the container invariant persists past the commit: a root client resize propagates to every member (members re-match the root's full frame size); a member resizing itself is snapped back to the root size; and if the root's node moves or rotates outside a drag (e.g. the space allocator re-places it after a resize), members re-assert their cascade offset relative to it. Without this, any later client resize drifts the stack layout apart (#18).
+- Input source(s): n/a (client/compositor-driven geometry changes)
+- Config keys: `zSurfaceMarginTop (1.0)`
+- Code: src/plugins/vr/qml/KwinTransientWindow.qml:36-86
+- Status: Working
 
 ---
 
@@ -933,7 +940,7 @@ Unverified where the key sequence's out-of-box availability matters.
 | VOC-SNAP-030 | Working | kwinvr-testQmlLogic (landing-pose math) — ghost rendering smoke only |
 | VOC-SNAP-040 | WIP | none — smoke only |
 | VOC-SNAP-050 | WIP | none — smoke only |
-| VOC-SNAP-060 | WIP | none — smoke only |
+| VOC-SNAP-060 | Working | kwinvr-testFlatSnapReplay (commit resizes member to root frame size, stackedOnto/stackIndex set; flat substrate) |
 | VOC-SNAP-070 | WIP | none — smoke only |
 | VOC-SNAP-080 | Unverified | none — smoke only |
 | VOC-SNAP-090 | Unverified | none — smoke only |
@@ -942,6 +949,7 @@ Unverified where the key sequence's out-of-box availability matters.
 | VOC-SNAP-120 | WIP | none — smoke only |
 | VOC-SNAP-130 | Unverified | none — smoke only |
 | VOC-SNAP-140 | Buggy | none — smoke only |
+| VOC-SNAP-150 | Working | kwinvr-testFlatSnapReplay (root resize propagates, member self-resize snaps back, cascade pose survives re-placement) |
 | VOC-MIRROR-010 | Working | none — smoke only |
 | VOC-MIRROR-020 | Working | none — smoke only |
 | VOC-MIRROR-030 | Working | none — smoke only |

--- a/src/plugins/vr/autotests/CMakeLists.txt
+++ b/src/plugins/vr/autotests/CMakeLists.txt
@@ -104,3 +104,12 @@ set_tests_properties(kwinvr-testFlatReplay PROPERTIES TIMEOUT 180)
 add_test(NAME kwinvr-testFlatHudReplay
     COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/flat-hud-replay.sh ${CMAKE_BINARY_DIR}/bin)
 set_tests_properties(kwinvr-testFlatHudReplay PROPERTIES TIMEOUT 180)
+
+# --- stack-size replay (M3, issue #18) ---
+# Two real Wayland clients, one stack-committed onto the other: the stack
+# must act as one rigid container — member matches root size at commit and
+# keeps matching through later resizes; cascade pose survives allocator
+# re-placement. SKIPs without the Qt 6 qml runtime.
+add_test(NAME kwinvr-testFlatSnapReplay
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/flat-snap-replay.sh ${CMAKE_BINARY_DIR}/bin)
+set_tests_properties(kwinvr-testFlatSnapReplay PROPERTIES TIMEOUT 180)

--- a/src/plugins/vr/autotests/flat-snap-replay.sh
+++ b/src/plugins/vr/autotests/flat-snap-replay.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Stack-size replay (M3, issue #18): two real Wayland clients are floated in
+# the 3D workspace and one is stack-committed onto the other. The stack must
+# behave as one rigid container: the member matches the root's size at commit
+# (VOC-SNAP-060) and KEEPS matching it — a later resize of the root propagates
+# to the member, and a member resizing itself is snapped back to the root size
+# (VOC-SNAP-150). Without that, layouts drift apart after any client resize.
+#
+# Usage: flat-snap-replay.sh <build-bin-dir>
+set -u
+. "$(dirname "$0")/vrtestlib.sh"
+vrtest_reexec "$@"
+
+BIN_DIR="${1:?usage: flat-snap-replay.sh <build-bin-dir>}"
+
+# Needs the Qt 6 qml runtime (a Qt 5 `qml` loads nothing on versionless
+# imports — see flat-replay.sh).
+QML_BIN=""
+for _c in /usr/lib/qt6/bin/qml "$(command -v qml6 2>/dev/null)" "$(command -v qml 2>/dev/null)"; do
+    [ -n "$_c" ] && [ -x "$_c" ] || continue
+    case "$("$_c" --version 2>/dev/null)" in
+        *" 6."*) QML_BIN=$_c; break ;;
+    esac
+done
+if [ -z "$QML_BIN" ]; then
+    echo "SKIP: Qt 6 qml runtime not found"
+    exit 0
+fi
+
+boot_flat_kwin "$BIN_DIR"
+activate_vr
+
+base=$(vreval 'flatScene.workspace.appWindows.count')
+
+cat > "$HOME/root.qml" <<'EOF'
+import QtQuick
+Window { visible: true; width: 500; height: 400; title: "snap-root"; color: "green" }
+EOF
+cat > "$HOME/member.qml" <<'EOF'
+import QtQuick
+Window { visible: true; width: 320; height: 240; title: "snap-member"; color: "orange" }
+EOF
+env -u QT_PLUGIN_PATH -u QT_FORCE_STDERR_LOGGING \
+    WAYLAND_DISPLAY=wayland-0 QT_QPA_PLATFORM=wayland \
+    setsid "$QML_BIN" "$HOME/root.qml" > "$HOME/clients.log" 2>&1 &
+CPID=$!
+env -u QT_PLUGIN_PATH -u QT_FORCE_STDERR_LOGGING \
+    WAYLAND_DISPLAY=wayland-0 QT_QPA_PLATFORM=wayland \
+    setsid "$QML_BIN" "$HOME/member.qml" >> "$HOME/clients.log" 2>&1 &
+CPID2=$!
+
+if ! vreval_wait 'flatScene.workspace.appWindows.count' "$((base + 2))" 15 > /dev/null; then
+    echo "--- clients.log:"; cat "$HOME/clients.log"
+    fail "clients never landed in the workspace (count $(vreval 'flatScene.workspace.appWindows.count'), base $base)"
+fi
+echo "ok: both clients entered the scene (count $base -> $((base + 2)))"
+
+# Resolve repeater indices by caption.
+winexpr() { # winexpr <caption> → JS expression for that KwinApplicationWindow
+    echo "(function(){const r=flatScene.workspace.appWindows; for(let i=0;i<r.count;i++){const w=r.objectAt(i); if(w&&w.client&&w.client.caption===\"$1\") return w} return null})()"
+}
+ROOTW=$(winexpr snap-root)
+MEMBW=$(winexpr snap-member)
+assert_eq "$(vreval "(!!$ROOTW).toString()")" "true" "root window resolved by caption"
+assert_eq "$(vreval "(!!$MEMBW).toString()")" "true" "member window resolved by caption"
+
+# Float both into the 3D workspace (drag-out path is VOC-PLACE; here we flip
+# the state directly — stacking only applies to VR-floating windows).
+vreval "$ROOTW.client.vr = true; $MEMBW.client.vr = true; \"ok\"" > /dev/null
+assert_eq "$(vreval "($ROOTW.client.vr && $MEMBW.client.vr).toString()")" "true" "both windows VR-floating"
+
+# Frame sizes include server-side decoration, so all asserts compare member
+# frame to root frame rather than to absolute pixel numbers.
+SIZES="$ROOTW.client.frameGeometry.width + 'x' + $ROOTW.client.frameGeometry.height + ' / ' + $MEMBW.client.frameGeometry.width + 'x' + $MEMBW.client.frameGeometry.height"
+FRAMES_MATCH="($MEMBW.client.frameGeometry.width === $ROOTW.client.frameGeometry.width && $MEMBW.client.frameGeometry.height === $ROOTW.client.frameGeometry.height).toString()"
+
+# --- VOC-SNAP-060: stack commit resizes member to root's full size ---
+vreval "flatScene.workspace.snap._commitSnap($MEMBW, $ROOTW, 5); \"ok\"" > /dev/null
+assert_eq "$(vreval "($MEMBW.stackedOnto === $ROOTW).toString()")" "true" "member stackedOnto root"
+assert_eq "$(vreval "$MEMBW.stackIndex")" "1" "member stackIndex"
+if ! vreval_wait "$FRAMES_MATCH" "true" 10 > /dev/null; then
+    fail "stack commit did not resize member to root size (root/member: $(vreval "$SIZES"))"
+fi
+echo "ok: stack commit resized member to root frame size ($(vreval "$SIZES"))"
+
+# --- VOC-SNAP-150 (#18): root resize propagates to stacked member ---
+rw0=$(vreval "$ROOTW.client.frameGeometry.width")
+vreval "KwinVrHelpers.windowResize($ROOTW.client, 140, 80); \"ok\"" > /dev/null
+if ! vreval_wait "$ROOTW.client.frameGeometry.width" "$((rw0 + 140))" 10 > /dev/null; then
+    fail "root never resized (root/member: $(vreval "$SIZES"))"
+fi
+if ! vreval_wait "$FRAMES_MATCH" "true" 10 > /dev/null; then
+    fail "#18 drift: member did not follow root resize (root/member: $(vreval "$SIZES"))"
+fi
+echo "ok: member followed root resize ($(vreval "$SIZES"))"
+
+# --- VOC-SNAP-150 (#18): member self-resize snaps back to container size ---
+vreval "KwinVrHelpers.windowResize($MEMBW.client, -200, -100); \"ok\"" > /dev/null
+sleep 2   # let the configure round-trip land before checking convergence
+if ! vreval_wait "$FRAMES_MATCH" "true" 10 > /dev/null; then
+    fail "#18 drift: member self-resize was not snapped back to root size (root/member: $(vreval "$SIZES"))"
+fi
+echo "ok: member self-resize snapped back to container size ($(vreval "$SIZES"))"
+
+# Cascade pose intact: member sits at (+step, -step, +step) in root-local
+# coords (step = zSurfaceMarginTop) regardless of the resizes above.
+off=$(vreval "(function(){const p=$ROOTW.mapPositionFromScene($MEMBW.scenePosition); const s=KWinVRConfig.zSurfaceMarginTop; return (Math.abs(p.x-s)<0.05 && Math.abs(p.y+s)<0.05 && Math.abs(p.z-s)<0.05).toString()})()")
+assert_eq "$off" "true" "cascade offset unchanged through resizes"
+
+# Detach clears stack state (and must stop the size-follow).
+vreval "flatScene.workspace.snap._detachFromStack($MEMBW); \"ok\"" > /dev/null
+assert_eq "$(vreval "($MEMBW.stackedOnto === null).toString()")" "true" "member detached"
+
+# Teardown
+kill -TERM -"$CPID" 2>/dev/null
+kill -TERM -"$CPID2" 2>/dev/null
+if ! vreval_wait 'flatScene.workspace.appWindows.count' "$base" 15 > /dev/null; then
+    fail "windows did not leave on client exit"
+fi
+echo "ok: scene emptied on client exit"
+
+echo "PASS: stack replay — commit size match, #18 size propagation, cascade pose, teardown"
+exit 0

--- a/src/plugins/vr/qml/KwinTransientWindow.qml
+++ b/src/plugins/vr/qml/KwinTransientWindow.qml
@@ -8,6 +8,8 @@ import QtQuick
 import QtQuick3D
 import org.kde.kwin.vr
 
+import "WindowSnapLogic.js" as SnapLogic
+
 Node {
     id: root
     visible: !root.client.minimized && root.client.opacity > 0 && (!KwinVrHelpers.screenLocked || client.lockScreen || client.lockScreenOverlay || client.inputMethod)
@@ -31,6 +33,54 @@ Node {
     // cascade (1 = first child, 2 = second, etc.).
     property var stackedOnto: null
     property int stackIndex: 0
+
+    // A stack is one rigid container: members match the root's full frame
+    // size (VOC-SNAP-060) and KEEP matching it (#18) — otherwise any later
+    // client resize drifts the layout apart. Watch both the root's geometry
+    // (propagate down) and our own (a member resizing itself snaps back).
+    // Converges: once sizes match the delta is zero and nothing is issued.
+    // Cascade offsets are size-independent, so no reposition is needed.
+    function _matchStackRootSize() {
+        if (!stackedOnto || !stackedOnto.client || !client)
+            return
+        const rg = stackedOnto.client.frameGeometry
+        const mg = client.frameGeometry
+        const dw = rg.width - mg.width
+        const dh = rg.height - mg.height
+        if (Math.abs(dw) > 0.5 || Math.abs(dh) > 0.5)
+            KwinVrHelpers.windowResize(client, dw, dh)
+    }
+    Connections {
+        // ?? null: undefined would not coerce to QObject*
+        target: (root.stackedOnto ? root.stackedOnto.client : null) ?? null
+        function onFrameGeometryChanged() { root._matchStackRootSize() }
+    }
+    Connections {
+        target: root.client
+        enabled: root.stackedOnto !== null
+        function onFrameGeometryChanged() { root._matchStackRootSize() }
+    }
+
+    // Same container rigidity for POSE (#18): if the root's node moves
+    // outside a drag (e.g. the space allocator re-places it after a resize),
+    // members must keep their cascade offset relative to it. During a root
+    // drag members are reparented under the root (VOC-SNAP-080) — transform
+    // inheritance already carries them, so skip while we're its child.
+    // Converges: a no-op write doesn't re-emit scenePositionChanged.
+    function _followStackRootPose() {
+        if (!stackedOnto || parent === stackedOnto)
+            return
+        const r = SnapLogic.landingPose(0, 0, 0, 0, KWinVRConfig.zSurfaceMarginTop,
+                                        SnapLogic.ActionStack, Math.max(stackIndex, 1))
+        KwinVrHelpers.setNodePositionFromScene(
+            root, stackedOnto.mapPositionToScene(Qt.vector3d(r.x, r.y, r.z)))
+        KwinVrHelpers.setNodeRotationFromScene(root, stackedOnto.sceneRotation)
+    }
+    Connections {
+        target: root.stackedOnto ?? null
+        function onScenePositionChanged() { root._followStackRootPose() }
+        function onSceneRotationChanged() { root._followStackRootPose() }
+    }
 
     // Emitted when this window becomes active and is part of a stack — so
     // WindowSnapManager can promote it to top of cascade.


### PR DESCRIPTION
Fixes #18 (snap container intrinsicSize → layout drift).

**Interpretation note for the owner** (issue text is one line — please redirect if I read it wrong): I read "snap container" as the stack group and "children don't propagate size up" as the container invariant not being maintained after commit — any later resize drifts the layout. If you instead meant a relayout of *side-snapped* (SnapLeft/Right/Above/Below) neighbors, those currently store no persistent relation at all; that's a design decision I left for #16 (batch ILayoutMode — multi-window relayout consistency) rather than inventing one overnight.

## What drifted (reproduced live on the flat substrate)
After a stack commit, the invariant "member = root full frame size at cascade offset" only held at the commit moment:
1. Root client resize → members kept their old size (repro: root 640x508, member stuck at 500x428).
2. Member self-resize → broke the uniform cascade.
3. The space allocator re-places the root node after its resize → members stayed at the old scene position (repro: cascade offset went from (1,−1,1) to (−2.5,1,1)).

## Fix
`KwinTransientWindow`, active only while `stackedOnto` is set:
- watches the root client's `frameGeometry` → re-matches size (deltas < 0.5px are no-ops, so it converges);
- watches its own `frameGeometry` → a member resizing itself snaps back to the container size;
- watches the root node's `scenePosition`/`sceneRotation` → re-asserts the cascade offset via `SnapLogic.landingPose` (single source of truth with the commit path); skipped while reparented under the root mid-drag (VOC-SNAP-080 transform inheritance already carries members).

Vocabulary: new **VOC-SNAP-150**; **VOC-SNAP-060** promoted to Working — `_commitSnap` is now verified live (the release-trigger path keeps its VOC-SNAP-050 uncertainty).

## Tests (flat substrate, per standing direction — hardware smoke deferred)
- `kwinvr-testFlatSnapReplay` (new, `flat-snap-replay.sh`): two real Wayland clients, one stack-committed onto the other via the test hook — commit size match (frame-relative, server-side decorations included), root-resize propagation, member self-resize snap-back, cascade pose intact through allocator re-placement, detach, teardown. SKIPs without the Qt 6 `qml` runtime (recorded in `doc/TEST_BASELINE.md`).

All 7 kwinvr ctest suites green locally. Note: will need a trivial rebase after #39 (same doc/CMake regions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)