### PR TITLE
Make testMockDrm fully device-free and un-quarantine it

### DIFF
--- a/autotests/drm/CMakeLists.txt
+++ b/autotests/drm/CMakeLists.txt
@@ -63,6 +63,11 @@ target_include_directories(LibDrmTest
 # Tests
 ########################################################
 add_executable(testMockDrm mockDrmTest.cpp)
+# Export the executable's symbols (-rdynamic) so the drm/gbm mocks in
+# mock_drm.cpp also interpose calls made from inside libkwin.so (e.g.
+# DrmDevice::open()'s gbm_create_device/drmGetCap) — that is what lets the
+# test run with no /dev/dri node at all (#36).
+set_target_properties(testMockDrm PROPERTIES ENABLE_EXPORTS ON)
 target_link_libraries(testMockDrm LibDrmTest Qt::Test)
 add_test(NAME kwin-testMockDrm COMMAND testMockDrm)
 ecm_mark_as_test(testMockDrm)

--- a/autotests/drm/mockDrmTest.cpp
+++ b/autotests/drm/mockDrmTest.cpp
@@ -44,43 +44,15 @@ Q_LOGGING_CATEGORY(KWIN_VIRTUALKEYBOARD, "kwin_virtualkeyboard", QtWarningMsg)
 
 static std::unique_ptr<MockGpu> findPrimaryDevice(int crtcCount)
 {
-#if !HAVE_LIBDRM_FAUX
-#if defined(Q_OS_LINUX)
-    // Workaround for libdrm being unaware of faux bus.
-    if (qEnvironmentVariableIsSet("CI")) {
-        int fd = open("/dev/dri/card1", O_RDWR | O_CLOEXEC);
-        if (fd == -1) {
-            return nullptr;
-        } else {
-            return std::make_unique<MockGpu>(fd, "/dev/dri/card1", crtcCount);
-        }
-    }
-#endif
-#endif
-
-    const int deviceCount = drmGetDevices2(0, nullptr, 0);
-    if (deviceCount <= 0) {
+    // Fully device-free (#36): every drm*/gbm call the backend makes on this
+    // GPU is interposed by mock_drm.cpp, keyed on the fd — so any open fd
+    // works and no /dev/dri node (nor the old CI vgem workaround) is needed.
+    // This also stops the test contending with a live session's real DRM.
+    int fd = open("/dev/null", O_RDWR | O_CLOEXEC);
+    if (fd == -1) {
         return nullptr;
     }
-
-    QList<drmDevice *> devices(deviceCount);
-    if (drmGetDevices2(0, devices.data(), devices.size()) < 0) {
-        return nullptr;
-    }
-    auto deviceCleanup = qScopeGuard([&devices]() {
-        drmFreeDevices(devices.data(), devices.size());
-    });
-
-    for (drmDevice *device : std::as_const(devices)) {
-        if (device->available_nodes & (1 << DRM_NODE_PRIMARY)) {
-            int fd = open(device->nodes[DRM_NODE_PRIMARY], O_RDWR | O_CLOEXEC);
-            if (fd != -1) {
-                return std::make_unique<MockGpu>(fd, device->nodes[DRM_NODE_PRIMARY], crtcCount);
-            }
-        }
-    }
-
-    return nullptr;
+    return std::make_unique<MockGpu>(fd, QStringLiteral("/dev/null"), crtcCount);
 }
 
 class DrmTest : public QObject

--- a/autotests/drm/mock_drm.cpp
+++ b/autotests/drm/mock_drm.cpp
@@ -12,6 +12,7 @@
 extern "C" {
 #include <libxcvt/libxcvt.h>
 }
+#include <gbm.h>
 #include <math.h>
 #include <unistd.h>
 
@@ -1346,4 +1347,68 @@ void drmModeFreePlane(drmModePlanePtr ptr)
         }
     }
     Q_UNREACHABLE();
+}
+
+// #36: DrmGpu::createNonMasterFd() asks libdrm for the device path behind
+// the fd, then re-opens it to marshal a non-master fd to lease clients.
+// Answer with the mock's devNode so that path keeps producing a valid fd
+// even when the "device" is /dev/null.
+char *drmGetDeviceNameFromFd2(int fd)
+{
+    GPU(fd, nullptr);
+    return strdup(gpu->devNode.toLocal8Bit().constData());
+}
+
+// The re-opened lease fd points at the mock devNode (/dev/null), where the
+// real drmIsMaster() reads ENOTTY as "is master" and the follow-up
+// drmDropMaster() fails. Nothing in this process ever holds real DRM
+// master, so always report non-master.
+int drmIsMaster(int fd)
+{
+    return 0;
+}
+
+// gbm mocks (#36): DrmDevice::open() in libkwin creates a gbm device for the
+// node it is handed. These tests never allocate through it — the QPainter
+// path only reaches gbm for dumb buffers, which go through
+// gbm_device_get_fd() + the mocked drmIoctl() — so a stub carrying the fd is
+// enough, and the whole suite runs with no /dev/dri node at all.
+//
+// NOTE: these calls (and DrmDevice's drmGetCap) come from libkwin.so, not
+// from the backend sources compiled into LibDrmTest, so they only resolve
+// here because the test executable exports its symbols (ENABLE_EXPORTS in
+// CMakeLists.txt). The drm mocks above get interposed the same way.
+
+struct gbm_device
+{
+    int fd;
+};
+
+gbm_device *gbm_create_device(int fd)
+{
+    return new gbm_device{fd};
+}
+
+void gbm_device_destroy(gbm_device *gbm)
+{
+    delete gbm;
+}
+
+int gbm_device_get_fd(gbm_device *gbm)
+{
+    return gbm->fd;
+}
+
+// Defensive: if a test ever reaches dmabuf allocation, fail it gracefully
+// instead of handing the stub device to the real libgbm.
+gbm_bo *gbm_bo_create(gbm_device *gbm, uint32_t width, uint32_t height, uint32_t format, uint32_t flags)
+{
+    errno = ENOTSUP;
+    return nullptr;
+}
+
+gbm_bo *gbm_bo_create_with_modifiers(gbm_device *gbm, uint32_t width, uint32_t height, uint32_t format, const uint64_t *modifiers, unsigned int count)
+{
+    errno = ENOTSUP;
+    return nullptr;
 }

--- a/ci/run-unit-tests.sh
+++ b/ci/run-unit-tests.sh
@@ -11,7 +11,15 @@ cd "$(dirname "$0")/.."
 
 integration_regex=$(grep -rhoP 'integrationTest\(NAME\s+\K\w+' autotests/integration/ \
     | sed 's/^/^kwin-/;s/$/$/' | paste -sd'|')
+# `|| true`: an empty quarantine list must not abort under pipefail, and an
+# empty $quarantine_regex must not leave a trailing `|` (an empty alternation
+# branch matches every test name, excluding everything).
 quarantine_regex=$(grep -v '^#' ci/unit-quarantine.txt | grep -v '^$' \
-    | sed 's/^/^/;s/$/$/' | paste -sd'|')
+    | sed 's/^/^/;s/$/$/' | paste -sd'|' || true)
 
-ctest --test-dir "$BUILD_DIR" --output-on-failure -E "$integration_regex|$quarantine_regex" "$@"
+exclude_regex="$integration_regex"
+if [ -n "$quarantine_regex" ]; then
+    exclude_regex="$exclude_regex|$quarantine_regex"
+fi
+
+ctest --test-dir "$BUILD_DIR" --output-on-failure -E "$exclude_regex" "$@"

--- a/ci/unit-quarantine.txt
+++ b/ci/unit-quarantine.txt
@@ -1,3 +1,2 @@
 # Unit tests excluded from the required CI set (one name per line).
 # Every entry must have a class + note in doc/TEST_BASELINE.md.
-kwin-testMockDrm

--- a/doc/TEST_BASELINE.md
+++ b/doc/TEST_BASELINE.md
@@ -21,7 +21,7 @@ in a container; expected green there.
 
 | Test | Evidence |
 |---|---|
-| `kwin-testMockDrm` (unit, **VR series' own lease test**) | aborted at 312s in batch; 18/18 pass in 136ms direct. **Also SIGSEGVs in the CI container** (SEGV_MAPERR at offset 0x18 right after initTestCase — null deref, likely assumes `/dev/dri` exists despite the mock). Quarantined in `ci/unit-quarantine.txt`; ticketed to make the mock truly device-free, since this is the test guarding the DRM-lease feature. |
+| `kwin-testMockDrm` (unit, **VR series' own lease test**) | **Un-quarantined (#36, CI-required).** Was: aborted at 312s in batch, SIGSEGV in the CI container (`findPrimaryDevice` returned null with no `/dev/dri`, then derefed). The mock is now truly device-free — the GPU "node" is `/dev/null`, with `gbm_create_device`/`drmGetDeviceNameFromFd2`/`drmIsMaster` interposed alongside the drm mocks (test built with `ENABLE_EXPORTS` so interposition reaches calls from libkwin.so). 18/18 in ~160ms, verified with `/dev/dri` bind-mounted empty; it no longer touches real DRM at all, so the batch-contention abort mode is gone too. |
 | `kwin-testXdgShellWindow` | 120s timeout in batch; 68/69 in 12s direct (the 1 fail is `testAppMenu`, which needs `dbus-run-session` — green with it) |
 | `kwin-testLockScreen` | 120s timeout in batch; 20/20 in 63s direct |
 | `kwin-testOutputChanges` | 120s timeout in batch; 92/92 in 14s direct |


### PR DESCRIPTION
Fixes #36

## Problem

`kwin-testMockDrm` — the unit test guarding the DRM-lease feature — SIGSEGV'd in the CI container (SEGV_MAPERR right after initTestCase) and was quarantined. Root cause: with no `/dev/dri`, `findPrimaryDevice()` returned `nullptr` and the tests dereferenced it. The mock only mocked the drm API; it still needed a *real* device node for the fd it keys its mocks on, and for `DrmDevice::open()` (real `::open` + `gbm_create_device`) inside libkwin.

## Fix

- **`findPrimaryDevice()` now opens `/dev/null`** — every drm/gbm call the backend makes on the GPU is interposed and keyed on the fd, so any open fd works. No device scan, no old `CI`-env `/dev/dri/card1` vgem workaround.
- **gbm interposition**: `gbm_create_device`/`gbm_device_destroy`/`gbm_device_get_fd` are stubbed in mock_drm.cpp (the stub just carries the fd; dumb allocation routes through `gbm_device_get_fd` + the already-mocked `drmIoctl`, and these tests never allocate). `gbm_bo_create*` stubs fail with ENOTSUP instead of handing the stub device to real libgbm.
- **Lease-fd path kept honest**: `drmGetDeviceNameFromFd2` answers with the mock devNode and `drmIsMaster` reports non-master, so `DrmGpu::createNonMasterFd()` still marshals a valid fd to lease clients (real libdrm read `/dev/null`'s ENOTTY as "is master").
- **`ENABLE_EXPORTS` on the test executable** — these calls come from libkwin.so, not the backend sources compiled into LibDrmTest, so the executable must export its symbols for the interposition to reach them. This is also documented in the mock.
- **Un-quarantined**: removed from `ci/unit-quarantine.txt`; `ci/run-unit-tests.sh` now handles an empty quarantine file (the old pipeline aborted under `pipefail`, and an empty regex branch in `-E` would have excluded *every* test).
- TEST_BASELINE.md Class 1 entry updated.

## Verification

- 18 passed / 0 failed / 1 skipped (pre-existing `testModeset` QSKIP), ~160ms
- Same result with `/dev/dri` bind-mounted empty (`unshare -m`) to simulate the CI container
- `ci/run-unit-tests.sh build -N` lists 71 tests including `kwin-testMockDrm`; nothing else excluded
- Side benefit: the test no longer touches real DRM at all, so its Class-1 batch-contention abort mode (312s hang alongside a live session) is structurally gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)