### PR TITLE
ci: vgem on the runner host — flat render assertions go hard in CI (#38)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,25 +15,30 @@ concurrency:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
-    # The job runs on the host (not `container:`) so it can modprobe vgem —
-    # a `container:` job cannot load kernel modules even with --privileged
-    # because the Arch image lacks the host kernel's .ko files. The build and
-    # tests still run in archlinux:base-devel, started manually below with
-    # /dev/dri passed through; mesa's kms_swrast driver on the vgem node gives
-    # kwin's virtual backend a real GL context, so kwinvr-testFlatBoot's
-    # frame-render assertion goes hard in CI instead of SKIPping (#38).
+    # The job runs on the host (not `container:`) so it can modprobe a virtual
+    # DRM module — a `container:` job cannot load kernel modules even with
+    # --privileged because the Arch image lacks the host kernel's .ko files.
+    # The build and tests still run in archlinux:base-devel, started manually
+    # below with /dev/dri passed through; mesa's kms_swrast driver on the
+    # vgem/vkms node gives kwin's virtual backend a real GL context, so
+    # kwinvr-testFlatBoot's frame-render assertion goes hard in CI instead of
+    # SKIPping (#38). KWINVR_REQUIRE_RHI=1 in the unit-test step makes that
+    # checkable: if GL ever silently regresses here, FlatBoot FAILS instead
+    # of skipping, so a green run proves the render assertion executed.
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Load vgem DRM node on the host
+      - name: Load a virtual DRM module on the host
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y -qq "linux-modules-extra-$(uname -r)"
-          # Ground truth on what DRM drivers the azure kernel actually ships
-          # (vgem was missing on 6.17.0-1015-azure — find a substitute).
+          # The azure 6.17 kernels ship vkms but NOT vgem (verified on
+          # 6.17.0-1015-azure); try vgem first in case that ever changes,
+          # fall back to vkms. kwin's virtual backend special-cases both to
+          # use the primary node (vkms exposes no render node), where mesa's
+          # kms_swrast can allocate gbm dumb buffers.
           uname -r
-          find "/lib/modules/$(uname -r)" -path '*drivers/gpu*' -o -name 'vgem*' -o -name 'vkms*' | sort
           sudo modprobe vgem || sudo modprobe vkms
           # Hard requirement: no node means render asserts silently degrade.
           ls -la /dev/dri
@@ -76,7 +81,7 @@ jobs:
             which glxgears || echo "glxgears NOT on PATH"
             ls -la /usr/bin/glxgears 2>/dev/null || true
             echo "PATH=$PATH"
-            # #38: the vgem node must be visible in here for GL via kms_swrast.
+            # #38: the vgem/vkms node must be visible in here for GL via kms_swrast.
             ls -la /dev/dri
           '
 
@@ -109,6 +114,9 @@ jobs:
           docker exec ci bash -ec '
             export QT_QPA_PLATFORM=offscreen
             export XDG_RUNTIME_DIR=$(mktemp -d)
+            # #38: GL must exist here (vgem/vkms via kms_swrast) — refuse the
+            # soft SKIP so the FlatBoot frame-render assertion provably runs.
+            export KWINVR_REQUIRE_RHI=1
             xvfb-run -a dbus-run-session bash ci/run-unit-tests.sh build
           '
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,11 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y -qq "linux-modules-extra-$(uname -r)"
-          sudo modprobe vgem
+          # Ground truth on what DRM drivers the azure kernel actually ships
+          # (vgem was missing on 6.17.0-1015-azure — find a substitute).
+          uname -r
+          find "/lib/modules/$(uname -r)" -path '*drivers/gpu*' -o -name 'vgem*' -o -name 'vkms*' | sort
+          sudo modprobe vgem || sudo modprobe vkms
           # Hard requirement: no node means render asserts silently degrade.
           ls -la /dev/dri
           test -e /dev/dri/card0 || test -e /dev/dri/card1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,81 +15,117 @@ concurrency:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
-    container:
-      image: archlinux:base-devel
-      options: --privileged
+    # The job runs on the host (not `container:`) so it can modprobe vgem —
+    # a `container:` job cannot load kernel modules even with --privileged
+    # because the Arch image lacks the host kernel's .ko files. The build and
+    # tests still run in archlinux:base-devel, started manually below with
+    # /dev/dri passed through; mesa's kms_swrast driver on the vgem node gives
+    # kwin's virtual backend a real GL context, so kwinvr-testFlatBoot's
+    # frame-render assertion goes hard in CI instead of SKIPping (#38).
     steps:
-      - name: Install dependencies
-        run: |
-          pacman -Syu --noconfirm
-          # runtime + build deps (kept in sync with PKGBUILD depends/makedepends)
-          pacman -S --noconfirm --needed \
-            git cmake ninja extra-cmake-modules kdoctools krunner \
-            plasma-wayland-protocols wayland-protocols python xorg-xwayland \
-            aurorae breeze iio-sensor-proxy plasma-activities kauth kcmutils \
-            kcolorscheme kconfig kcoreaddons kcrash kdbusaddons kdeclarative \
-            kdecoration kglobalaccel kglobalacceld kguiaddons ki18n kidletime \
-            kirigami kitemmodels knewstuff knighttime knotifications kpackage \
-            kquickcharts kscreenlocker kservice ksvg kwayland kwidgetsaddons \
-            kwindowsystem kxmlgui layer-shell-qt lcms2 libcanberra libdisplay-info libdrm \
-            libei libepoxy libevdev libinput libpipewire \
-            libqaccessibilityclient-qt6 libxcb libxcvt libxkbcommon mesa milou \
-            pipewire-session-manager libplasma qt6-5compat qt6-base \
-            qt6-declarative qt6-svg qt6-tools systemd-libs wayland \
-            xcb-util-keysyms xcb-util-wm qt6-quick3d openxr mesa-demos \
-            xorg-server-xvfb dbus
-
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Load vgem DRM node on the host
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq "linux-modules-extra-$(uname -r)"
+          sudo modprobe vgem
+          # Hard requirement: no node means render asserts silently degrade.
+          ls -la /dev/dri
+          test -e /dev/dri/card0 || test -e /dev/dri/card1
+
+      - name: Start build container
+        run: |
+          docker run -d --name ci --privileged \
+            --device /dev/dri \
+            -v "$GITHUB_WORKSPACE:/work" -w /work \
+            archlinux:base-devel sleep infinity
+
+      - name: Install dependencies
+        run: |
+          docker exec ci bash -ec '
+            pacman -Syu --noconfirm
+            # runtime + build deps (kept in sync with PKGBUILD depends/makedepends)
+            pacman -S --noconfirm --needed \
+              git cmake ninja extra-cmake-modules kdoctools krunner \
+              plasma-wayland-protocols wayland-protocols python xorg-xwayland \
+              aurorae breeze iio-sensor-proxy plasma-activities kauth kcmutils \
+              kcolorscheme kconfig kcoreaddons kcrash kdbusaddons kdeclarative \
+              kdecoration kglobalaccel kglobalacceld kguiaddons ki18n kidletime \
+              kirigami kitemmodels knewstuff knighttime knotifications kpackage \
+              kquickcharts kscreenlocker kservice ksvg kwayland kwidgetsaddons \
+              kwindowsystem kxmlgui layer-shell-qt lcms2 libcanberra libdisplay-info libdrm \
+              libei libepoxy libevdev libinput libpipewire \
+              libqaccessibilityclient-qt6 libxcb libxcvt libxkbcommon mesa milou \
+              pipewire-session-manager libplasma qt6-5compat qt6-base \
+              qt6-declarative qt6-svg qt6-tools systemd-libs wayland \
+              xcb-util-keysyms xcb-util-wm qt6-quick3d openxr mesa-demos \
+              xorg-server-xvfb dbus
+          '
+
       - name: Environment diagnostics
         run: |
-          # Breadcrumbs for quarantine triage (doc/TEST_BASELINE.md):
-          # glxgears exec fails in this container despite mesa-demos.
-          which glxgears || echo "glxgears NOT on PATH"
-          ls -la /usr/bin/glxgears 2>/dev/null || true
-          echo "PATH=$PATH"
+          docker exec ci bash -ec '
+            # Breadcrumbs for quarantine triage (doc/TEST_BASELINE.md):
+            # glxgears exec fails in this container despite mesa-demos.
+            which glxgears || echo "glxgears NOT on PATH"
+            ls -la /usr/bin/glxgears 2>/dev/null || true
+            echo "PATH=$PATH"
+            # #38: the vgem node must be visible in here for GL via kms_swrast.
+            ls -la /dev/dri
+          '
 
       - name: XR import fence
-        run: bash ci/check-xr-imports.sh
+        run: docker exec ci bash ci/check-xr-imports.sh
 
       - name: qmllint (advisory)
         # Advisory until the existing QML is lint-clean; the import fence above
         # is the blocking check. Tighten this once M2 lands.
         continue-on-error: true
         run: |
-          /usr/lib/qt6/bin/qmllint src/plugins/vr/qml/*.qml || true
+          docker exec ci bash -ec '/usr/lib/qt6/bin/qmllint src/plugins/vr/qml/*.qml || true'
 
       - name: Configure
         run: |
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          cmake -B build -G Ninja \
-            -DCMAKE_INSTALL_PREFIX=/usr \
-            -DCMAKE_INSTALL_LIBEXECDIR=lib \
-            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DBUILD_TESTING=ON
+          docker exec ci bash -ec '
+            git config --global --add safe.directory /work
+            cmake -B build -G Ninja \
+              -DCMAKE_INSTALL_PREFIX=/usr \
+              -DCMAKE_INSTALL_LIBEXECDIR=lib \
+              -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+              -DBUILD_TESTING=ON
+          '
 
       - name: Build
-        run: cmake --build build
+        run: docker exec ci cmake --build build
 
       - name: Unit tests
         run: |
-          export QT_QPA_PLATFORM=offscreen
-          export XDG_RUNTIME_DIR=$(mktemp -d)
-          xvfb-run -a dbus-run-session bash ci/run-unit-tests.sh build
+          docker exec ci bash -ec '
+            export QT_QPA_PLATFORM=offscreen
+            export XDG_RUNTIME_DIR=$(mktemp -d)
+            xvfb-run -a dbus-run-session bash ci/run-unit-tests.sh build
+          '
 
       - name: Integration tests (required subset)
         run: |
           # Quarantine list: ci/integration-quarantine.txt, triaged in
           # doc/TEST_BASELINE.md. Un-quarantining tests is progress.
-          export QT_QPA_PLATFORM=offscreen
-          export XDG_RUNTIME_DIR=$(mktemp -d)
-          xvfb-run -a dbus-run-session bash ci/run-integration-tests.sh build
+          docker exec ci bash -ec '
+            export QT_QPA_PLATFORM=offscreen
+            export XDG_RUNTIME_DIR=$(mktemp -d)
+            xvfb-run -a dbus-run-session bash ci/run-integration-tests.sh build
+          '
 
       - name: Install tree artifact
         run: |
-          DESTDIR="$PWD/install-tree" cmake --install build
-          tar -C install-tree -czf kwin-vr-install-tree.tar.gz .
+          docker exec ci bash -ec '
+            DESTDIR="$PWD/install-tree" cmake --install build
+            tar -C install-tree -czf kwin-vr-install-tree.tar.gz .
+          '
+          # Bind-mounted files are root-owned; make sure the runner user can read it.
+          sudo chmod a+r kwin-vr-install-tree.tar.gz
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/doc/TEST_BASELINE.md
+++ b/doc/TEST_BASELINE.md
@@ -75,7 +75,7 @@ kernel module and no live session. If they still fail, bisect against
 
 | Test | Condition | Behavior |
 |---|---|---|
-| `kwinvr-testFlatBoot` | No RHI scene graph (no `/dev/dri` → software compositing → "Qt Quick 3D is not functional") | Frame-render assertion SKIPs on that exact log marker only; boot/DBus/QML-error asserts still apply. Hard assertion anywhere GL exists — **including CI since #38**: the workflow loads `vgem` on the runner host and passes `/dev/dri` into the container, so mesa's `kms_swrast` gives the virtual backend a real GL context. |
+| `kwinvr-testFlatBoot` | No RHI scene graph (no `/dev/dri` → software compositing → "Qt Quick 3D is not functional") | Frame-render assertion SKIPs on that exact log marker only; boot/DBus/QML-error asserts still apply. Hard assertion anywhere GL exists — **including CI since #38**: the workflow loads `vgem` (or `vkms` — the azure kernels ship only vkms; kwin's virtual backend special-cases both to use the primary node) on the runner host and passes `/dev/dri` into the container, so mesa's `kms_swrast` gives the virtual backend a real GL context. CI also sets `KWINVR_REQUIRE_RHI=1`, which turns the SKIP into a FAIL — a green CI run therefore *proves* the frame-render assertion executed. |
 | `kwinvr-testFlatReplay` | Qt 6 `qml` runtime missing | Wayland-client placement section SKIPs (a Qt 5 `qml` in PATH is rejected — it loads nothing on versionless imports); interaction asserts still apply. |
 | `kwinvr-testFlatHudReplay` | Qt 6 `qml` runtime missing, or `org.kde.layershell` QML module not installed (layer-shell-qt) | Whole test SKIPs — it has no client-free section; the #17 lift math stays pinned by `kwinvr-testQmlLogic` regardless. |
 

--- a/doc/TEST_BASELINE.md
+++ b/doc/TEST_BASELINE.md
@@ -75,7 +75,7 @@ kernel module and no live session. If they still fail, bisect against
 
 | Test | Condition | Behavior |
 |---|---|---|
-| `kwinvr-testFlatBoot` | No RHI scene graph (CI container has no `/dev/dri` → software compositing → "Qt Quick 3D is not functional") | Frame-render assertion SKIPs on that exact log marker only; boot/DBus/QML-error asserts still apply. Hard assertion anywhere GL exists. Tracked in #38. |
+| `kwinvr-testFlatBoot` | No RHI scene graph (no `/dev/dri` → software compositing → "Qt Quick 3D is not functional") | Frame-render assertion SKIPs on that exact log marker only; boot/DBus/QML-error asserts still apply. Hard assertion anywhere GL exists — **including CI since #38**: the workflow loads `vgem` on the runner host and passes `/dev/dri` into the container, so mesa's `kms_swrast` gives the virtual backend a real GL context. |
 | `kwinvr-testFlatReplay` | Qt 6 `qml` runtime missing | Wayland-client placement section SKIPs (a Qt 5 `qml` in PATH is rejected — it loads nothing on versionless imports); interaction asserts still apply. |
 | `kwinvr-testFlatHudReplay` | Qt 6 `qml` runtime missing, or `org.kde.layershell` QML module not installed (layer-shell-qt) | Whole test SKIPs — it has no client-free section; the #17 lift math stays pinned by `kwinvr-testQmlLogic` regardless. |
 

--- a/src/backends/virtual/virtual_backend.cpp
+++ b/src/backends/virtual/virtual_backend.cpp
@@ -46,17 +46,19 @@ static std::unique_ptr<DrmDevice> findRenderDevice()
     });
 
     for (drmDevice *device : std::as_const(devices)) {
-        // If it's a vgem device, prefer the primary node because gbm will attempt to allocate
-        // dumb buffers and they can be allocated only on the primary node.
+        // If it's a vgem or vkms device, prefer the primary node because gbm will attempt
+        // to allocate dumb buffers and they can be allocated only on the primary node.
+        // (vkms added for kwin-vr #38: CI kernels without vgem still ship vkms, and
+        // mesa's kms_swrast works on any dumb-buffer-capable primary node.)
         int nodeType = DRM_NODE_RENDER;
         if (device->bustype == DRM_BUS_PLATFORM) {
-            if (strcmp(device->businfo.platform->fullname, "vgem") == 0) {
+            if (strcmp(device->businfo.platform->fullname, "vgem") == 0 || strcmp(device->businfo.platform->fullname, "vkms") == 0) {
                 nodeType = DRM_NODE_PRIMARY;
             }
         }
 #if HAVE_LIBDRM_FAUX
         if (device->bustype == DRM_BUS_FAUX) {
-            if (strcmp(device->businfo.faux->name, "vgem") == 0) {
+            if (strcmp(device->businfo.faux->name, "vgem") == 0 || strcmp(device->businfo.faux->name, "vkms") == 0) {
                 nodeType = DRM_NODE_PRIMARY;
             }
         }

--- a/src/plugins/vr/autotests/flatboot-smoke.sh
+++ b/src/plugins/vr/autotests/flatboot-smoke.sh
@@ -43,11 +43,17 @@ for _ in $(seq 1 10); do
 done
 
 if [ "$grabbed" != 1 ]; then
-    # Quick3D needs an RHI-backed scene graph; the CI container has no
-    # /dev/dri and kwin falls back to software compositing, so View3D
-    # renders nothing there by design. Skip ONLY on that exact marker —
-    # anywhere GL exists this stays a hard assertion. Tracked in #38.
+    # Quick3D needs an RHI-backed scene graph; without /dev/dri kwin falls
+    # back to software compositing and View3D renders nothing by design.
+    # Skip ONLY on that exact marker — anywhere GL exists this stays a hard
+    # assertion. CI sets KWINVR_REQUIRE_RHI=1 (#38: the workflow loads a
+    # virtual DRM module on the runner host precisely so GL exists there),
+    # which turns this skip into a failure: a green CI run then PROVES the
+    # frame-render assertion ran, instead of silently degrading.
     if grep -q 'Qt Quick 3D is not functional' "$LOG"; then
+        if [ "${KWINVR_REQUIRE_RHI:-0}" = 1 ]; then
+            fail "no RHI scene graph, but KWINVR_REQUIRE_RHI=1 — GL was required in this environment (#38)"
+        fi
         echo "SKIP: no RHI scene graph in this environment — render assertion skipped (boot asserts still apply)"
     else
         fail "captureWorkspaceFrame never produced a frame"


### PR DESCRIPTION
## Summary
- Restructures the workflow from a `container:` job to a **host job** that loads the `vgem` kernel module, then starts `archlinux:base-devel` manually with `--device /dev/dri` and runs every step via `docker exec`.
- Why: a `container:` job can never `modprobe` — the Arch image doesn't carry the host kernel's `.ko` files, even with `--privileged`. Verified during #38 triage.
- With a vgem node visible, mesa's `kms_swrast` gives kwin's virtual backend a real GL context, so `kwinvr-testFlatBoot`'s frame-render assertion **goes hard in CI** instead of SKIPping (the skip is keyed to the exact "Qt Quick 3D is not functional" marker, which should no longer appear).
- The vgem node is asserted loudly twice: the host step fails if `/dev/dri/card*` doesn't materialize, and the in-container diagnostics list `/dev/dri`.
- `doc/TEST_BASELINE.md` FlatBoot row updated.

Closes #38.

## Test plan
- [x] YAML validates
- [ ] CI run on this PR: "Load vgem" step shows a `/dev/dri` node; FlatBoot log shows the render assertion ran (no SKIP line)
- [ ] Full unit + integration sets still green under GL-capable virtual backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)