### PR TITLE
vr: auto-float windows when their host output is hidden (#26)

### DIFF
--- a/doc/TEST_BASELINE.md
+++ b/doc/TEST_BASELINE.md
@@ -79,6 +79,7 @@ kernel module and no live session. If they still fail, bisect against
 | `kwinvr-testFlatReplay` | Qt 6 `qml` runtime missing | Wayland-client placement section SKIPs (a Qt 5 `qml` in PATH is rejected — it loads nothing on versionless imports); interaction asserts still apply. |
 | `kwinvr-testFlatHudReplay` | Qt 6 `qml` runtime missing, or `org.kde.layershell` QML module not installed (layer-shell-qt) | Whole test SKIPs — it has no client-free section; the #17 lift math stays pinned by `kwinvr-testQmlLogic` regardless. |
 | `kwinvr-testFlatSnapReplay` | Qt 6 `qml` runtime missing | Whole test SKIPs — it is built around two real Wayland clients. |
+| `kwinvr-testFlatFloatReplay` | Qt 6 `qml` runtime missing | Whole test SKIPs — it is built around two real Wayland clients. The #26 allocator cone cap stays pinned by `kwinvr-testSpaceAllocator3D` regardless. |
 
 ## Reproduce
 

--- a/doc/VOCABULARY.md
+++ b/doc/VOCABULARY.md
@@ -433,6 +433,13 @@ retest, so commit-path behaviors are at best WIP.
 - Code: src/plugins/vr/qml/XrScene.qml:482-486,501-515
 - Status: Working
 
+### VOC-MIRROR-065: Hidden mirror releases its allocator/follow-mode slot
+**Given** a pseudomirror leaves the scene graph (hidden per VOC-MIRROR-060, or destroyed) **Then** it unregisters from the space allocator and follow mode, freeing its (typically front-center) angular slot for future placements; re-showing it re-registers.
+- Input source(s): n/a (config / output hotplug)
+- Config keys: `hideVirtualDisplay (true)`
+- Code: src/plugins/vr/qml/VrWorkspaceScene.qml:498-515
+- Status: Working
+
 ### VOC-MIRROR-070: Transient windows stack in front of their parent
 **Given** a window has transient children (menus, popups, dialogs) **Then** they render as planes Z-stacked in front of the parent window — menus first, then transient normal windows, each separated by computed Z margins; popups may extend beyond screen bounds for VR windows (custom popup bounds resolver unions the transient chain geometry).
 - Input source(s): n/a (window hierarchy)
@@ -440,12 +447,19 @@ retest, so commit-path behaviors are at best WIP.
 - Code: src/plugins/vr/qml/KwinTransientWindow.qml:93-135, src/plugins/vr/kwinvr.cpp:331-342, src/plugins/vr/windowmodelfilter.cpp:417-445
 - Status: Working
 
+### VOC-MIRROR-080: Windows auto-float when their host mirror disappears
+**Given** a toplevel with `vr == false` **When** its host output's pseudomirror is absent or detached from the scene graph (hidden virtual display, output not rendered) — at window birth or later **Then** the window promotes itself to `vr = true` and is placed in free space by the allocator (VOC-PLACE-010 path), facing the viewpoint. The promotion is **one-way**: re-showing the mirror does not snap the window back (auto-floated windows stay floating).
+- Input source(s): n/a (output/mirror state)
+- Config keys: `hideVirtualDisplay (true)`
+- Code: src/plugins/vr/qml/VrWorkspaceScene.qml:601-651
+- Status: Working
+
 ---
 
 ## PLACE — automatic 3D placement (SpaceAllocator3D)
 
 ### VOC-PLACE-010: New screens placed at the nearest free angular slot
-**Given** existing tracked objects (pseudomirrors, VR windows) **When** a new pseudomirror is created **Then** the allocator projects all tracked objects to angular bounds from the viewpoint and scans candidate positions on the viewing sphere — center first, then concentric rings — at `distance` cm, returning the first slot whose angular bounds (object size + `spacing` 0.1 rad) overlap nothing; the mirror is placed there facing the viewpoint.
+**Given** existing tracked objects (pseudomirrors, VR windows) **When** a new pseudomirror is created **Then** the allocator projects all tracked objects to angular bounds from the viewpoint and scans candidate positions on the viewing sphere — center first, then concentric rings, **capped at 90° from forward** (front hemisphere only; nothing ever spawns behind the user) — at `distance` cm, returning the first slot whose angular bounds (object size + `spacing` 0.1 rad) overlap nothing; the mirror is placed there facing the viewpoint.
 - Input source(s): n/a (automatic)
 - Config keys: `distance (100)`; spacing/granularity hardcoded (0.1 / 0.1) in XrScene
 - Code: src/plugins/vr/spaceallocator3d.cpp:265-301,225-263, src/plugins/vr/qml/XrScene.qml:468-475,488-495
@@ -459,7 +473,7 @@ retest, so commit-path behaviors are at best WIP.
 - Status: Working
 
 ### VOC-PLACE-030: Fallback placement straight ahead
-**Given** no free slot exists anywhere on the sphere **Then** the allocator returns the point directly forward at `distance` (overlapping whatever is there).
+**Given** no free slot exists anywhere in the front hemisphere **Then** the allocator returns the point directly forward at `distance` (overlapping whatever is there).
 - Input source(s): n/a (automatic)
 - Config keys: `distance (100)`
 - Code: src/plugins/vr/spaceallocator3d.cpp:299-300
@@ -955,11 +969,13 @@ Unverified where the key sequence's out-of-box availability matters.
 | VOC-MIRROR-030 | Working | none — smoke only |
 | VOC-MIRROR-040 | Working | none — smoke only |
 | VOC-MIRROR-050 | Working | none — smoke only |
-| VOC-MIRROR-060 | Working | none — smoke only |
+| VOC-MIRROR-060 | Working | kwinvr-testFlatFloatReplay (Virtual-T mirror hidden at start) |
+| VOC-MIRROR-065 | Working | none — smoke only |
 | VOC-MIRROR-070 | Working | none — smoke only |
-| VOC-PLACE-010 | Working | none — smoke only |
+| VOC-MIRROR-080 | Working | kwinvr-testFlatFloatReplay (promotion on detach, birth-on-hidden, one-way) |
+| VOC-PLACE-010 | Working | kwinvr-testSpaceAllocator3D (front-hemisphere cap, slot scan) |
 | VOC-PLACE-020 | Working | none — smoke only |
-| VOC-PLACE-030 | Working | none — smoke only |
+| VOC-PLACE-030 | Working | kwinvr-testSpaceAllocator3D (fallback on hemisphere exhaustion) |
 | VOC-PLACE-040 | Working | none — smoke only |
 | VOC-FOLLOW-010 | Working | none — smoke only |
 | VOC-FOLLOW-020 | Working | none — smoke only |

--- a/src/plugins/vr/autotests/CMakeLists.txt
+++ b/src/plugins/vr/autotests/CMakeLists.txt
@@ -113,3 +113,12 @@ set_tests_properties(kwinvr-testFlatHudReplay PROPERTIES TIMEOUT 180)
 add_test(NAME kwinvr-testFlatSnapReplay
     COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/flat-snap-replay.sh ${CMAKE_BINARY_DIR}/bin)
 set_tests_properties(kwinvr-testFlatSnapReplay PROPERTIES TIMEOUT 180)
+
+# --- auto-float replay (M3, issue #26) ---
+# A real Wayland client lands on the VR virtual screen, whose pseudomirror is
+# hidden by default: the window must promote itself to vr-floating and get
+# allocator placement, and must stay floating when the mirror is re-shown
+# (one-way promotion). SKIPs without the Qt 6 qml runtime.
+add_test(NAME kwinvr-testFlatFloatReplay
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/flat-float-replay.sh ${CMAKE_BINARY_DIR}/bin)
+set_tests_properties(kwinvr-testFlatFloatReplay PROPERTIES TIMEOUT 180)

--- a/src/plugins/vr/autotests/flat-float-replay.sh
+++ b/src/plugins/vr/autotests/flat-float-replay.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Auto-float replay (M3, issue #26): a window whose host output's pseudomirror
+# is detached from the scene must promote itself to vr-floating instead of
+# rendering into a dead subtree ("no app windows in VR" baseline bug), and the
+# promotion is one-way — re-showing the mirror must NOT snap it back.
+#
+# The mirror is detached via the test hook (parent=null), the same mechanism
+# VOC-MIRROR-060's hideVirtualDisplay binding uses; that config path is pinned
+# by the Virtual-T hidden-at-start assertion below.
+#
+# Covers: VOC-MIRROR-080 (auto-float on hidden host output: promotion of live
+# windows AND windows born on an already-hidden output), placement via the
+# shared allocator (VOC-PLACE-020 path for windows).
+#
+# Usage: flat-float-replay.sh <build-bin-dir>
+set -u
+. "$(dirname "$0")/vrtestlib.sh"
+vrtest_reexec "$@"
+
+BIN_DIR="${1:?usage: flat-float-replay.sh <build-bin-dir>}"
+
+# Needs the Qt 6 qml runtime for real Wayland clients.
+QML_BIN=""
+for _c in /usr/lib/qt6/bin/qml "$(command -v qml6 2>/dev/null)" "$(command -v qml 2>/dev/null)"; do
+    [ -n "$_c" ] && [ -x "$_c" ] || continue
+    case "$("$_c" --version 2>/dev/null)" in
+        *" 6."*) QML_BIN=$_c; break ;;
+    esac
+done
+if [ -z "$QML_BIN" ]; then
+    echo "SKIP: Qt 6 qml runtime not found"
+    exit 0
+fi
+
+boot_flat_kwin "$BIN_DIR"
+activate_vr
+
+MIRRORS='flatScene.workspace.outputMirrors'
+
+# VOC-MIRROR-060 wiring: the VR virtual screen's mirror is hidden by default
+if ! vreval_wait "(!!$MIRRORS.outputMap[\"Virtual-T\"]).toString()" "true" 15 > /dev/null; then
+    fail "no pseudomirror tracked for Virtual-T (outputs: $(vreval "Object.keys($MIRRORS.outputMap).join(\",\")"))"
+fi
+assert_eq "$(vreval "($MIRRORS.outputMap[\"Virtual-T\"].parent === null).toString()")" \
+    "true" "Virtual-T mirror hidden at start (hideVirtualDisplay default)"
+
+spawn_client() { # <name> -> sets CPID, echoes nothing
+    cat > "$HOME/$1.qml" <<EOF
+import QtQuick
+Window { visible: true; width: 320; height: 240; title: "$1"; color: "purple" }
+EOF
+    env -u QT_PLUGIN_PATH -u QT_FORCE_STDERR_LOGGING \
+        WAYLAND_DISPLAY=wayland-0 QT_QPA_PLATFORM=wayland \
+        setsid "$QML_BIN" "$HOME/$1.qml" > "$HOME/$1.log" 2>&1 &
+    CPID=$!
+}
+
+# --- baseline: a client on a visible mirror stays in screen state ---
+base=$(vreval 'flatScene.workspace.appWindows.count')
+spawn_client clientA
+APID=$CPID
+if ! vreval_wait 'flatScene.workspace.appWindows.count' "$((base + 1))" 15 > /dev/null; then
+    echo "--- clientA.log:"; cat "$HOME/clientA.log"
+    fail "clientA never appeared (count stuck at $(vreval 'flatScene.workspace.appWindows.count'), base $base)"
+fi
+A="flatScene.workspace.appWindows.objectAt($base)"
+HOST=$(vreval "$A.client.output.name")
+sleep 1   # let deferred maybeAutoFloat (Component.onCompleted) settle
+assert_eq "$(vreval "$A.client.vr.toString()")" "false" "window on visible mirror ($HOST) stays in screen state"
+assert_eq "$(vreval "$A.hostOutputHidden.toString()")" "false" "hostOutputHidden false while mirror attached"
+
+# --- VOC-MIRROR-080: detaching the host mirror promotes the window ---
+vreval "$MIRRORS.outputMap[\"$HOST\"].parent = null; \"ok\"" > /dev/null
+if ! vreval_wait "$A.client.vr.toString()" "true" 10 > /dev/null; then
+    fail "window never promoted to vr after its mirror detached (hostOutputHidden=$(vreval "$A.hostOutputHidden.toString()"))"
+fi
+echo "ok: window promoted to vr=true when host mirror detached"
+assert_eq "$(vreval "($A.parent !== null).toString()")" "true" "floated window is in a live subtree"
+
+# Allocator placement gave it real size and a non-degenerate pose
+w=$(vreval "$A.itemSize.width.toFixed(0)")
+[ "${w:-0}" != "0" ] || fail "floated window has zero itemSize — not placed"
+dist=$(vreval "$A.scenePosition.length().toFixed(0)")
+[ "${dist:-0}" != "0" ] || fail "floated window sits at the scene origin — findFreePosition never ran"
+echo "ok: floated window placed (itemSize.width=$w, |scenePosition|=$dist)"
+
+# --- birth on a hidden output: a new client must float from the start ---
+spawn_client clientB
+if ! vreval_wait 'flatScene.workspace.appWindows.count' "$((base + 2))" 15 > /dev/null; then
+    echo "--- clientB.log:"; cat "$HOME/clientB.log"
+    fail "clientB never appeared"
+fi
+B="flatScene.workspace.appWindows.objectAt($((base + 1)))"
+if ! vreval_wait "$B.client.vr.toString()" "true" 10 > /dev/null; then
+    fail "window born on hidden output never promoted to vr"
+fi
+echo "ok: window born on hidden output floats from the start"
+
+# --- one-way promotion: re-attaching the mirror must not snap them back ---
+vreval "$MIRRORS.outputMap[\"$HOST\"].parent = $MIRRORS; \"ok\"" > /dev/null
+sleep 1
+assert_eq "$(vreval "$A.client.vr.toString()")" "true" "promoted window stays floating after mirror re-shown"
+assert_eq "$(vreval "$B.client.vr.toString()")" "true" "born-floating window stays floating after mirror re-shown"
+
+# Cleanup: client exit removes the windows
+kill -TERM -"$APID" -"$CPID" 2>/dev/null
+if ! vreval_wait 'flatScene.workspace.appWindows.count' "$base" 15 > /dev/null; then
+    fail "client windows did not leave on exit"
+fi
+echo "ok: windows left the scene on client exit"
+
+echo "PASS: auto-float replay — promotion on detach, birth-on-hidden, one-way, placement"
+exit 0

--- a/src/plugins/vr/autotests/testspaceallocator3d.cpp
+++ b/src/plugins/vr/autotests/testspaceallocator3d.cpp
@@ -10,6 +10,9 @@
 #include <QTest>
 #include <QtQuick3D/private/qquick3dnode_p.h>
 
+#include <memory>
+#include <vector>
+
 using namespace KWin;
 
 // SpaceAllocator3D reads object size via QQmlProperty(sizePropertyName), which
@@ -107,6 +110,35 @@ private Q_SLOTS:
         }
         const QVector3D pos = alloc.findFreePosition(60, 40);
         QVERIFY((pos - QVector3D(0, 0, -150)).length() < 1.0f);
+    }
+
+    void allocationsNeverLandBehindTheViewer()
+    {
+        // #26 housekeeping: the candidate sweep is capped at 90° from forward,
+        // so windows never spawn behind the user's head as the front fills up.
+        // Saturate well past the front hemisphere's capacity for 60x40 items
+        // and require every returned position to stay in the front half-space
+        // (forward is -Z; "behind" means z > 0). Saturation overflow must take
+        // the VOC-PLACE-030 fallback (dead center) instead of wrapping around.
+        SpaceAllocator3D alloc;
+        alloc.setDistance(150.0);
+
+        std::vector<std::unique_ptr<SizedNode>> occupants;
+        bool sawFallback = false;
+        for (int i = 0; i < 100; ++i) {
+            const QVector3D pos = alloc.findFreePosition(60, 40);
+            QVERIFY2(pos.z() <= 0.5f,
+                     qPrintable(QStringLiteral("allocation %1 landed behind the viewer: z=%2").arg(i).arg(pos.z())));
+            if (i > 0 && (pos - QVector3D(0, 0, -150)).length() < 1.0f) {
+                sawFallback = true; // hemisphere exhausted, fallback reused the center
+            }
+            auto occupant = std::make_unique<SizedNode>();
+            occupant->setItemSize(QSizeF(60, 40));
+            occupant->setPosition(pos);
+            alloc.registerObject(occupant.get());
+            occupants.push_back(std::move(occupant));
+        }
+        QVERIFY2(sawFallback, "100 allocations never exhausted the front hemisphere — cap not effective");
     }
 
     void twoOccupantsLeaveDistinctFreeSpots()

--- a/src/plugins/vr/qml/VrWorkspaceScene.qml
+++ b/src/plugins/vr/qml/VrWorkspaceScene.qml
@@ -497,6 +497,20 @@ Node {
                     }
                     Component.onDestruction: {
                         delete outputMirrorRepeater.outputMap[output.name]
+                        spaceAllocator.unregisterObject(pseudoOutput)
+                        followMode.unregisterObject(pseudoOutput)
+                    }
+                    // Free the mirror's allocator slot while it is hidden, so
+                    // auto-floated windows can claim the prime front-center
+                    // real estate instead of getting pushed to the fringe.
+                    onIsVirtualHiddenChanged: {
+                        if (isVirtualHidden) {
+                            spaceAllocator.unregisterObject(pseudoOutput)
+                            followMode.unregisterObject(pseudoOutput)
+                        } else {
+                            spaceAllocator.registerObject(pseudoOutput)
+                            followMode.registerObject(pseudoOutput)
+                        }
                     }
                 }
                 function findPseudoOutputByOutput(output: QtObject): KwinPseudoOutputMirror {
@@ -584,10 +598,56 @@ Node {
                         return Qt.size(sz.width / kwinAppWindow.ppu, sz.height / kwinAppWindow.ppu);
                     }
 
+                    // Pseudomirror for this window's host output. May be null if
+                    // the output has no mirror, and may have parent===null when
+                    // the mirror is hidden (e.g. hideVirtualDisplay). Either case
+                    // means the window would render into a detached subtree — we
+                    // promote it to vr=true so it floats instead (#26). Read
+                    // outputMap directly (not findPseudoOutputByOutput) because
+                    // the latter walks repeater.children, which feeds back into
+                    // this binding and produces a binding loop.
+                    readonly property QtObject hostMirror: {
+                        const name = kwinAppWindow.client.output ? kwinAppWindow.client.output.name : ""
+                        return outputMirrorRepeater.outputMap[name] ?? null
+                    }
+                    readonly property bool hostOutputHidden:
+                        !hostMirror || hostMirror.parent === null
+
                     function registerForSpaceAllocator() {
                         spaceAllocator.registerObject(kwinAppWindow)
                     }
-                    Component.onCompleted: Qt.callLater(kwinAppWindow.registerForSpaceAllocator)
+
+                    // Place this window in free 3D space via the shared allocator.
+                    // Used when the window auto-floats because its host output is
+                    // hidden / missing. turnToFace (not KeepRoll) because the
+                    // handle may carry arbitrary roll from prior follow-mode
+                    // activity, which would otherwise flip spawns upside down.
+                    function placeInFreeSpace() {
+                        if (itemSize.width <= 0 || itemSize.height <= 0) {
+                            return
+                        }
+                        const globalPos = spaceAllocator.findFreePosition(itemSize.width, itemSize.height)
+                        kwinAppWindow.position = allWindowsGrabHandle.mapPositionFromScene(globalPos)
+                        KwinVrHelpers.turnToFace(kwinAppWindow, spaceAllocator.viewpoint)
+                    }
+
+                    // One-way promotion: if this window's host output is not
+                    // renderable, flip it into vr-floating. Idempotent — once
+                    // client.vr is true the guard short-circuits, so re-showing
+                    // the host mirror does NOT snap the window back (per design:
+                    // auto-floated windows stay floating). Placement deferred so
+                    // the state-machine's parent swap (screen→vr) applies first.
+                    function maybeAutoFloat() {
+                        if (!kwinAppWindow.client.vr && kwinAppWindow.hostOutputHidden) {
+                            kwinAppWindow.client.vr = true
+                            Qt.callLater(kwinAppWindow.placeInFreeSpace)
+                        }
+                    }
+                    onHostOutputHiddenChanged: Qt.callLater(kwinAppWindow.maybeAutoFloat)
+                    Component.onCompleted: {
+                        Qt.callLater(kwinAppWindow.registerForSpaceAllocator)
+                        Qt.callLater(kwinAppWindow.maybeAutoFloat)
+                    }
 
                     states: [
                         State {

--- a/src/plugins/vr/spaceallocator3d.cpp
+++ b/src/plugins/vr/spaceallocator3d.cpp
@@ -276,8 +276,11 @@ QVector3D SpaceAllocator3D::findFreePosition(qreal width, qreal height)
     // Angular step based on object size and search granularity
     const qreal angularStep = (std::atan(width / m_distance) + m_spacing) * m_searchGranularity;
 
-    // Generate all candidate positions on the sphere (sorted by distance from center)
-    const auto candidates = generateSpherePoints(angularStep, M_PI);
+    // Generate candidate positions (sorted by distance from center), capped at
+    // 90° from forward — new spawns stay in the front hemisphere where the user
+    // can at least see them peripherally, instead of landing behind the head as
+    // the front fills up. Overflow goes to the VOC-PLACE-030 fallback instead.
+    const auto candidates = generateSpherePoints(angularStep, M_PI_2);
 
     // Check each candidate position
     for (const auto &[az, el] : candidates) {


### PR DESCRIPTION
Closes #26 (features 1–3 of the archived auto-float work).

Salvaged from archive commit `95947c85b6` per the salvage policy — re-implemented against the M2 renderer seam using the archive as reference, not merged wholesale.

## What

- **Auto-float (VOC-MIRROR-080):** every app window watches its host output's pseudomirror. If the mirror is missing or detached from the scene (e.g. `hideVirtualDisplay` on the VR virtual screen, VOC-MIRROR-060), the window promotes itself to `vr = true` and gets placed via the shared `SpaceAllocator3D` (`turnToFace`, so roll left over from follow-mode can't spawn it upside down). Promotion is **one-way**: re-showing the mirror never snaps the window back. This kills the baseline "window opens on the hidden virtual screen and is invisible" bug.
- **Mirror slot release (VOC-MIRROR-065):** a hidden mirror unregisters from the allocator and follow-mode, so auto-floated windows can claim the prime front-center positions instead of being pushed to the fringe.
- **Front-hemisphere cap (VOC-PLACE-010/030):** `SpaceAllocator3D::findFreePosition`'s candidate sweep is capped at 90° from forward. Spawns never land behind the user's head; hemisphere exhaustion takes the existing center fallback.

Implementation notes: `hostMirror` reads `outputMap` directly (not `findPseudoOutputByOutput`, which walks `repeater.children` and produces a binding loop); placement is deferred with `Qt.callLater` so the screen→vr state-machine parent swap applies first.

## Tests

- New **`kwinvr-testFlatFloatReplay`**: two real Wayland clients against flat-mode kwin — asserts the Virtual-T mirror is hidden at start, promotion on mirror detach, allocator placement (non-degenerate size + pose), birth-on-already-hidden output floats from the start, and one-way promotion after re-attach. SKIPs without the Qt 6 `qml` runtime (documented in TEST_BASELINE).
- New unit case `allocationsNeverLandBehindTheViewer`: saturates the allocator past front-hemisphere capacity, requires every position in the front half-space and the fallback to engage.
- Full kwinvr suite: **8/8 locally** (FlatFloatReplay 8.05s).

Docs: VOC-MIRROR-065 + VOC-MIRROR-080 added, VOC-PLACE-010/030 updated, status matrix + TEST_BASELINE rows updated.

## Deliberately out of scope

- **Focus-pull** (`VrFollowMode.focusOn` + `pullAppWinForward` from the archive commit) — follow-up PR.
- **Toggle-grab** — left out; `VrInputSurface`'s current latch logic supersedes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)