### PR TITLE
vr: focus pull — activation slides a floating window to depth and pans to it (#26)

### DIFF
--- a/doc/TEST_BASELINE.md
+++ b/doc/TEST_BASELINE.md
@@ -80,6 +80,7 @@ kernel module and no live session. If they still fail, bisect against
 | `kwinvr-testFlatHudReplay` | Qt 6 `qml` runtime missing, or `org.kde.layershell` QML module not installed (layer-shell-qt) | Whole test SKIPs — it has no client-free section; the #17 lift math stays pinned by `kwinvr-testQmlLogic` regardless. |
 | `kwinvr-testFlatSnapReplay` | Qt 6 `qml` runtime missing | Whole test SKIPs — it is built around two real Wayland clients. |
 | `kwinvr-testFlatFloatReplay` | Qt 6 `qml` runtime missing | Whole test SKIPs — it is built around two real Wayland clients. The #26 allocator cone cap stays pinned by `kwinvr-testSpaceAllocator3D` regardless. |
+| `kwinvr-testFlatFocusReplay` | Qt 6 `qml` runtime missing | Whole test SKIPs — it drives real activation edges with three Wayland clients (focus pull VOC-FOCUS-010/020). Boots with `followEnabled=false` so the pan can only come from `focusOn`'s explicit camera. The C++ pan override itself stays pinned by `kwinvr-testVrFollowMode` (unit, never skips). |
 
 ## Reproduce
 

--- a/doc/VOCABULARY.md
+++ b/doc/VOCABULARY.md
@@ -534,6 +534,24 @@ retest, so commit-path behaviors are at best WIP.
 
 ---
 
+## FOCUS — focus pull (slide-and-pan on activation)
+
+### VOC-FOCUS-010: Activating a floating window pulls it to depth and pans the view
+**Given** a vr-floating window not involved in a dock/stack **When** its client becomes active programmatically (taskbar, alt+tab, scripts) **Then** its scene pose is saved and it slides along its camera→window ray to the average camera distance of the other floating windows (the configured `distance` if there are none), turns to face the camera, and `VrFollowMode.focusOn(window, camera)` pans the world until the window sits inside the stop-FOV — even while the followMode `camera` binding is null (follow disabled, hover/grab/menu gating): the explicit camera drives the pan. Angular position is preserved (no teleport to center); the pan covers the rest. Already-pulled and snap-involved windows are left alone.
+- Input source(s): window activation (any source)
+- Config keys: `distance (100)`, `followStopFovH/V (5)`
+- Code: src/plugins/vr/qml/VrWorkspaceScene.qml (pullAppWinForward, _averageFloatingDistance, _isSnapInvolved), src/plugins/vr/vrfollowmode.cpp (focusOn, effectiveCamera)
+- Status: Working (flat-validated)
+
+### VOC-FOCUS-020: Defocus restores the pulled window's pose; a grab cancels the restore
+**Given** a window pulled by VOC-FOCUS-010 **When** its client deactivates **Then** any in-flight pan for it is cancelled (`VrFollowMode.unfocus`) and its saved scene position and rotation are restored (only while it is still vr-floating). **When** instead the user grabs the pulled window **Then** the saved pose is dropped and the pan cancelled — manual placement wins; later defocus restores nothing. A destroyed or unregistered pan target stops the pan safely.
+- Input source(s): window deactivation; pick-ray grab
+- Config keys: none
+- Code: src/plugins/vr/qml/VrWorkspaceScene.qml (_restoreFocusedPullPose, grab Connections), src/plugins/vr/vrfollowmode.cpp (unfocus, clearFocusOverride)
+- Status: Working (flat-validated)
+
+---
+
 ## HUD — camera-pinned overlay surfaces
 
 ### VOC-HUD-010: Overlay windows pinned to the HUD plane
@@ -983,6 +1001,8 @@ Unverified where the key sequence's out-of-box availability matters.
 | VOC-FOLLOW-040 | Working | none — smoke only |
 | VOC-FOLLOW-050 | Working | none — smoke only |
 | VOC-FOLLOW-060 | Working | none — smoke only |
+| VOC-FOCUS-010 | Working | kwinvr-testFlatFocusReplay (pull+pan on real activation edges; flat substrate) + kwinvr-testVrFollowMode (focusOn pan with null camera binding, no-op in FOV) |
+| VOC-FOCUS-020 | Working | kwinvr-testFlatFocusReplay (pose restore on defocus) + kwinvr-testVrFollowMode (unfocus cancel, destroy/unregister teardown) |
 | VOC-HUD-010 | Working | kwinvr-testFlatHudReplay (layer-shell dock + xdg-popup admitted to / leave the HUD; flat substrate) + kwinvr-testQmlLogic (cylinder placement math) |
 | VOC-HUD-020 | Working | none — smoke only |
 | VOC-HUD-030 | Working | none — smoke only |

--- a/src/plugins/vr/autotests/CMakeLists.txt
+++ b/src/plugins/vr/autotests/CMakeLists.txt
@@ -60,6 +60,40 @@ target_link_libraries(testVrHelpers
 )
 add_test(NAME kwinvr-testHelpers COMMAND testVrHelpers)
 
+# --- VrFollowMode focus pull (#26 follow-up, VOC-FOCUS-010/020) ---
+# Exercises focusOn(): the explicit-camera pan override used by the
+# focus-pull behavior, including teardown via destroy/unregister mid-pan.
+add_executable(testVrFollowMode
+    testvrfollowmode.cpp
+    ../vrfollowmode.cpp
+    ../kwinvrhelpers.cpp
+    ../kwinvirtualscreenhandle.cpp
+    ../kwingraphicshelpers.cpp
+)
+ecm_qt_declare_logging_category(testVrFollowMode
+    HEADER kwinvr_logging.h
+    IDENTIFIER KWINVR
+    CATEGORY_NAME kwinvr
+    DEFAULT_SEVERITY Warning
+)
+# Same epoxy ordering constraint as the plugin (see ../CMakeLists.txt)
+target_compile_options(testVrFollowMode PRIVATE -include epoxy/gl.h)
+target_link_libraries(testVrFollowMode
+    kwin
+    Qt::Test
+    Qt6::GuiPrivate
+    Qt6::Quick
+    Qt6::QuickPrivate
+    Qt6::Quick3D
+    Qt6::Quick3DPrivate
+    Qt6::Quick3DXr
+    Qt6::Quick3DXrPrivate
+    KF6::ConfigGui
+    KF6::WindowSystem
+    KDecoration3::KDecoration
+)
+add_test(NAME kwinvr-testVrFollowMode COMMAND testVrFollowMode)
+
 # --- kcfg defaults + persistence round-trip ---
 add_executable(testVrConfig testvrconfig.cpp)
 kconfig_add_kcfg_files(testVrConfig GENERATE_MOC ../kwinvrconfig.kcfgc)
@@ -122,3 +156,12 @@ set_tests_properties(kwinvr-testFlatSnapReplay PROPERTIES TIMEOUT 180)
 add_test(NAME kwinvr-testFlatFloatReplay
     COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/flat-float-replay.sh ${CMAKE_BINARY_DIR}/bin)
 set_tests_properties(kwinvr-testFlatFloatReplay PROPERTIES TIMEOUT 180)
+
+# --- focus-pull replay (M3, #26 follow-up) ---
+# Real activation edges (new client steals focus, killing it hands focus
+# back): activating a far-off vr-floating window pulls it to depth, faces it,
+# and pans the world into stop-FOV; deactivation restores its saved pose.
+# SKIPs without the Qt 6 qml runtime.
+add_test(NAME kwinvr-testFlatFocusReplay
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/flat-focus-replay.sh ${CMAKE_BINARY_DIR}/bin)
+set_tests_properties(kwinvr-testFlatFocusReplay PROPERTIES TIMEOUT 180)

--- a/src/plugins/vr/autotests/flat-focus-replay.sh
+++ b/src/plugins/vr/autotests/flat-focus-replay.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Focus-pull replay (M3, #26 follow-up): activating a far-off vr-floating
+# window must pull it to the sibling-average depth along its cam→window ray,
+# face it to the user, and pan the world (followMode.focusOn with an explicit
+# camera — the property binding is null-gated whenever followEnabled is off,
+# which is the default) until it is centered. Deactivating it must restore
+# its saved pose.
+#
+# Trigger is the real one: KWin activation edges (a new client steals focus,
+# killing it hands focus back), not a direct pullAppWinForward() call.
+#
+# Covers: VOC-FOCUS-010 (pull + pan on activation), VOC-FOCUS-020 (pose
+# restore on deactivation). The C++ pan override internals (teardown on
+# destroy/unregister, no-op in FOV) are pinned by kwinvr-testVrFollowMode.
+#
+# Usage: flat-focus-replay.sh <build-bin-dir>
+set -u
+. "$(dirname "$0")/vrtestlib.sh"
+vrtest_reexec "$@"
+
+BIN_DIR="${1:?usage: flat-focus-replay.sh <build-bin-dir>}"
+
+# Needs the Qt 6 qml runtime for real Wayland clients.
+QML_BIN=""
+for _c in /usr/lib/qt6/bin/qml "$(command -v qml6 2>/dev/null)" "$(command -v qml 2>/dev/null)"; do
+    [ -n "$_c" ] && [ -x "$_c" ] || continue
+    case "$("$_c" --version 2>/dev/null)" in
+        *" 6."*) QML_BIN=$_c; break ;;
+    esac
+done
+if [ -z "$QML_BIN" ]; then
+    echo "SKIP: Qt 6 qml runtime not found"
+    exit 0
+fi
+
+# followEnabled=false makes the scenario deterministic (normal follow mode
+# would legitimately re-pan the world toward the restored window, masking
+# the restore) AND pins the very case focusOn exists for: the followMode
+# camera binding is null the whole time, so only the explicit camera handed
+# to focusOn() can drive the pan (the #26 archive bug).
+VRTEST_EXTRA_CONFIG=$'followEnabled=false\n'
+boot_flat_kwin "$BIN_DIR"
+activate_vr
+
+base=$(vreval 'flatScene.workspace.appWindows.count')
+
+spawn_client() { # <caption> -> sets CPID
+    cat > "$HOME/$1.qml" <<EOF
+import QtQuick
+Window { visible: true; width: 320; height: 240; title: "$1"; color: "teal" }
+EOF
+    env -u QT_PLUGIN_PATH -u QT_FORCE_STDERR_LOGGING \
+        WAYLAND_DISPLAY=wayland-0 QT_QPA_PLATFORM=wayland \
+        setsid "$QML_BIN" "$HOME/$1.qml" > "$HOME/$1.log" 2>&1 &
+    CPID=$!
+}
+
+winexpr() { # winexpr <caption> → JS expression for that KwinApplicationWindow
+    echo "(function(){const r=flatScene.workspace.appWindows; for(let i=0;i<r.count;i++){const w=r.objectAt(i); if(w&&w.client&&w.client.caption===\"$1\") return w} return null})()"
+}
+
+# --- subject: one vr-floating window, parked far behind the viewer ---
+spawn_client focus-subject
+APID=$CPID
+if ! vreval_wait 'flatScene.workspace.appWindows.count' "$((base + 1))" 15 > /dev/null; then
+    echo "--- focus-subject.log:"; cat "$HOME/focus-subject.log"
+    fail "subject client never appeared (count $(vreval 'flatScene.workspace.appWindows.count'), base $base)"
+fi
+A=$(winexpr focus-subject)
+assert_eq "$(vreval "(!!$A).toString()")" "true" "subject window resolved by caption"
+
+vreval "$A.client.vr = true; \"ok\"" > /dev/null
+assert_eq "$(vreval "$A.client.vr.toString()")" "true" "subject is VR-floating"
+assert_eq "$(vreval "$A.client.active.toString()")" "true" "freshly spawned subject is the active window"
+
+# Park it far away and BEHIND the camera: out of follow FOV so the pan must
+# run, and far off the sibling-average depth so the slide is observable.
+vreval "KwinVrHelpers.setNodePositionFromScene($A, Qt.vector3d(0, 0, 600)); \"ok\"" > /dev/null
+FARPOS='Qt.vector3d(0, 0, 600)'
+assert_eq "$(vreval "($A.scenePosition.minus($FARPOS).length() < 1).toString()")" \
+    "true" "subject parked at the far pose"
+
+# --- a second client steals focus; no pull existed, so nothing moves ---
+spawn_client focus-stealer
+SPID=$CPID
+if ! vreval_wait 'flatScene.workspace.appWindows.count' "$((base + 2))" 15 > /dev/null; then
+    echo "--- focus-stealer.log:"; cat "$HOME/focus-stealer.log"
+    fail "stealer client never appeared"
+fi
+if ! vreval_wait "$A.client.active.toString()" "false" 10 > /dev/null; then
+    fail "stealer never took focus from the subject"
+fi
+assert_eq "$(vreval "($A.scenePosition.minus($FARPOS).length() < 1).toString()")" \
+    "true" "deactivation without a prior pull moves nothing"
+assert_eq "$(vreval '(flatScene.workspace._focusedPullPose === null).toString()')" \
+    "true" "no pull pose saved for a vr=false activation"
+
+# --- VOC-FOCUS-010: focus comes back → pull + pan ---
+kill -TERM -"$SPID" 2>/dev/null
+if ! vreval_wait "$A.client.active.toString()" "true" 15 > /dev/null; then
+    fail "subject never re-activated after the stealer exited"
+fi
+if ! vreval_wait "(flatScene.workspace._focusedPullPose !== null && flatScene.workspace._focusedPullPose.window === $A).toString()" "true" 10 > /dev/null; then
+    fail "activation did not save a pull pose for the subject"
+fi
+# Slide: distance to camera == sibling-average depth, which with no other
+# floating windows is the configured default distance.
+DIST_EXPR="$A.scenePosition.minus(flatScene.workspace.camera.scenePosition).length()"
+WANT=$(vreval 'flatScene.workspace.distance')
+near=$(vreval "(Math.abs($DIST_EXPR - flatScene.workspace.distance) < 2).toString()")
+assert_eq "$near" "true" "subject slid to default depth (|cam→win| $(vreval "$DIST_EXPR.toFixed(1)"), want $WANT)"
+# Pan: the world rotates until the subject sits inside stop-FOV of the camera
+# — even though followMode.camera is null (followEnabled defaults off); the
+# explicit camera handed to focusOn() must drive it (the #26 archive bug).
+CENTERED="(function(){const cam=flatScene.workspace.camera; const p=cam.mapPositionFromScene($A.scenePosition); if (p.z >= 0) return \"behind\"; const h=Math.abs(Math.atan2(p.x, -p.z)) * 180 / Math.PI; const v=Math.abs(Math.atan2(p.y, -p.z)) * 180 / Math.PI; return (h <= KWinVRConfig.followStopFovH + 2 && v <= KWinVRConfig.followStopFovV + 2).toString()})()"
+if ! vreval_wait "$CENTERED" "true" 30 > /dev/null; then
+    fail "world pan never centered the subject (camera-local: $(vreval "JSON.stringify(flatScene.workspace.camera.mapPositionFromScene($A.scenePosition))"))"
+fi
+echo "ok: activation pulled the subject to depth and panned it into stop-FOV"
+
+# --- VOC-FOCUS-020: defocus restores the saved pose ---
+spawn_client focus-third
+TPID=$CPID
+if ! vreval_wait "$A.client.active.toString()" "false" 15 > /dev/null; then
+    echo "--- focus-third.log:"; cat "$HOME/focus-third.log"
+    fail "third client never took focus"
+fi
+if ! vreval_wait "($A.scenePosition.minus($FARPOS).length() < 1).toString()" "true" 10 > /dev/null; then
+    fail "deactivation did not restore the far pose (now at $(vreval "JSON.stringify($A.scenePosition)"))"
+fi
+assert_eq "$(vreval '(flatScene.workspace._focusedPullPose === null).toString()')" \
+    "true" "pull pose cleared after restore"
+echo "ok: deactivation restored the saved pose"
+
+# Cleanup: client exit removes the windows
+kill -TERM -"$APID" -"$TPID" 2>/dev/null
+if ! vreval_wait 'flatScene.workspace.appWindows.count' "$base" 15 > /dev/null; then
+    fail "client windows did not leave on exit"
+fi
+
+echo "PASS: focus-pull replay — pull+pan on activation, pose restore on defocus"
+exit 0

--- a/src/plugins/vr/autotests/testvrfollowmode.cpp
+++ b/src/plugins/vr/autotests/testvrfollowmode.cpp
@@ -1,0 +1,202 @@
+/*
+    SPDX-FileCopyrightText: 2026 bake
+
+    SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+#include "../vrfollowmode.h"
+
+#include <QSignalSpy>
+#include <QTest>
+#include <QtMath>
+#include <QtQuick3D/private/qquick3dnode_p.h>
+
+using namespace KWin;
+
+// Focus-pull pan (#26 follow-up, VOC-FOCUS-020): focusOn must run the frame
+// loop with its explicit camera even while the normal `camera` binding is
+// null (the QML scene null-gates it during hover/grab/menu), pan the
+// rotation target until the node reaches the stop-FOV, then clear itself.
+class TestVrFollowMode : public QObject
+{
+    Q_OBJECT
+
+    // Angle (degrees) between camera forward (-Z) and the direction to the
+    // node, in the horizontal plane — the same quantity the FOV checks use.
+    static float hAngleTo(const QQuick3DNode *camera, const QQuick3DNode *node)
+    {
+        const QVector3D toNode = node->scenePosition() - camera->scenePosition();
+        const QVector3D localDir = camera->mapDirectionFromScene(toNode).normalized();
+        return qAbs(qRadiansToDegrees(qAtan2(localDir.x(), -localDir.z())));
+    }
+
+private Q_SLOTS:
+    void focusOnPansNodeIntoStopFov()
+    {
+        QQuick3DNode scene;
+        QQuick3DNode camera;
+        camera.setParent(&scene);
+        camera.setParentItem(&scene); // origin, facing -Z
+
+        QQuick3DNode handle;
+        handle.setParent(&scene);
+        handle.setParentItem(&scene);
+        handle.setPosition(QVector3D(0, 0, -150));
+
+        QQuick3DNode window;
+        window.setParent(&handle);
+        window.setParentItem(&handle);
+        // Scene position (50, 0, 150): behind the viewer, well outside FOV.
+        window.setPosition(QVector3D(50, 0, 300));
+
+        VrFollowMode follow;
+        follow.setRotationTarget(&handle);
+        follow.registerObject(&window);
+        // The normal camera binding stays null — exactly the hover/grab/menu
+        // gating focusOn exists to bypass.
+        QVERIFY(!follow.camera());
+        QVERIFY(qAbs(hAngleTo(&camera, &window)) > follow.fovH());
+
+        follow.focusOn(&window, &camera);
+        QVERIFY(follow.active());
+
+        // The 16ms frame loop pans the handle around the camera pivot until
+        // the window reaches the stop-FOV, then deactivates.
+        QTRY_VERIFY_WITH_TIMEOUT(!follow.active(), 15000);
+        QVERIFY(hAngleTo(&camera, &window) <= follow.stopFovH() + 1.0f);
+        // In front of the viewer, not behind.
+        QVERIFY(window.scenePosition().z() < 0.0f);
+    }
+
+    void focusOnNoOpsWhenAlreadyInFov()
+    {
+        QQuick3DNode scene;
+        QQuick3DNode camera;
+        camera.setParent(&scene);
+        camera.setParentItem(&scene);
+
+        QQuick3DNode handle;
+        handle.setParent(&scene);
+        handle.setParentItem(&scene);
+
+        QQuick3DNode window;
+        window.setParent(&handle);
+        window.setParentItem(&handle);
+        window.setPosition(QVector3D(0, 0, -150)); // dead ahead
+
+        VrFollowMode follow;
+        follow.setRotationTarget(&handle);
+        follow.registerObject(&window);
+
+        const QVector3D before = window.scenePosition();
+        follow.focusOn(&window, &camera);
+        QVERIFY(!follow.active());
+        QTest::qWait(100);
+        QCOMPARE(window.scenePosition(), before);
+    }
+
+    void destroyedTargetStopsThePan()
+    {
+        QQuick3DNode scene;
+        QQuick3DNode camera;
+        camera.setParent(&scene);
+        camera.setParentItem(&scene);
+
+        QQuick3DNode handle;
+        handle.setParent(&scene);
+        handle.setParentItem(&scene);
+        handle.setPosition(QVector3D(0, 0, -150));
+
+        auto *window = new QQuick3DNode;
+        window->setParent(&handle);
+        window->setParentItem(&handle);
+        window->setPosition(QVector3D(50, 0, 300));
+
+        VrFollowMode follow;
+        follow.setRotationTarget(&handle);
+        follow.registerObject(window);
+        follow.focusOn(window, &camera);
+        QVERIFY(follow.active());
+
+        delete window; // mid-pan
+        // Override clears; with the normal camera binding still null the
+        // frame loop must shut down instead of spinning on a dead target.
+        QTRY_VERIFY(!follow.active());
+    }
+
+    void unfocusCancelsThePan()
+    {
+        QQuick3DNode scene;
+        QQuick3DNode camera;
+        camera.setParent(&scene);
+        camera.setParentItem(&scene);
+
+        QQuick3DNode handle;
+        handle.setParent(&scene);
+        handle.setParentItem(&scene);
+        handle.setPosition(QVector3D(0, 0, -150));
+
+        QQuick3DNode window;
+        window.setParent(&handle);
+        window.setParentItem(&handle);
+        window.setPosition(QVector3D(50, 0, 300));
+
+        QQuick3DNode other;
+        other.setParent(&handle);
+        other.setParentItem(&handle);
+
+        VrFollowMode follow;
+        follow.setRotationTarget(&handle);
+        follow.registerObject(&window);
+        follow.focusOn(&window, &camera);
+        QVERIFY(follow.active());
+
+        // Wrong node: the pan keeps going.
+        follow.unfocus(&other);
+        QVERIFY(follow.active());
+
+        // Right node: the pan cancels — this is what the QML pose restore
+        // relies on, or the override would drag the world after the
+        // restored window.
+        follow.unfocus(&window);
+        QTRY_VERIFY(!follow.active());
+        const QVector3D frozen = window.scenePosition();
+        QTest::qWait(100);
+        QCOMPARE(window.scenePosition(), frozen);
+    }
+
+    void unregisterClearsTheOverride()
+    {
+        QQuick3DNode scene;
+        QQuick3DNode camera;
+        camera.setParent(&scene);
+        camera.setParentItem(&scene);
+
+        QQuick3DNode handle;
+        handle.setParent(&scene);
+        handle.setParentItem(&scene);
+        handle.setPosition(QVector3D(0, 0, -150));
+
+        QQuick3DNode window;
+        window.setParent(&handle);
+        window.setParentItem(&handle);
+        window.setPosition(QVector3D(50, 0, 300));
+
+        VrFollowMode follow;
+        follow.setRotationTarget(&handle);
+        follow.registerObject(&window);
+        follow.focusOn(&window, &camera);
+        QVERIFY(follow.active());
+
+        follow.unregisterObject(&window);
+        QVERIFY(!follow.active());
+
+        // The pan must actually have stopped: pose frozen from here on.
+        const QVector3D frozen = window.scenePosition();
+        QTest::qWait(100);
+        QCOMPARE(window.scenePosition(), frozen);
+    }
+};
+
+QTEST_GUILESS_MAIN(TestVrFollowMode)
+#include "testvrfollowmode.moc"

--- a/src/plugins/vr/autotests/vrtestlib.sh
+++ b/src/plugins/vr/autotests/vrtestlib.sh
@@ -55,7 +55,9 @@ boot_flat_kwin() {
     export HOME=$(mktemp -d) XDG_RUNTIME_DIR=$(mktemp -d)
     chmod 700 "$XDG_RUNTIME_DIR"
     mkdir -p "$HOME/.config"
-    printf '[General]\ndisplayMode=Flat\n' > "$HOME/.config/kwinvr"
+    # Tests may pre-set VRTEST_EXTRA_CONFIG with extra [General] kwinvr keys
+    # (newline-separated) to pin config-dependent behavior deterministically.
+    printf '[General]\ndisplayMode=Flat\n%s' "${VRTEST_EXTRA_CONFIG:-}" > "$HOME/.config/kwinvr"
 
     export QT_PLUGIN_PATH="$bin_dir"
     export QT_LOGGING_RULES="kwinvr.debug=true"

--- a/src/plugins/vr/qml/VrWorkspaceScene.qml
+++ b/src/plugins/vr/qml/VrWorkspaceScene.qml
@@ -67,6 +67,115 @@ Node {
     function die() {  }
     function resetView() { allWindows.resetView() }
 
+    /* -------- focus pull (#26 follow-up, VOC-FOCUS-010/020) --------
+       On window activation (taskbar, alt+tab, scripts) a far-off vr-floating
+       window slides along its cam→window ray to the sibling-average depth and
+       faces the user; followMode pans the world so it ends up centered. On
+       defocus the window's prior pose is restored. */
+
+    // Saved scene pose of the focused window; null when no pull is active.
+    property var _focusedPullPose: null
+
+    function _restoreFocusedPullPose() {
+        if (!_focusedPullPose)
+            return
+        const pose = _focusedPullPose
+        _focusedPullPose = null
+        // Cancel any in-flight pan first — restoring the pose moves the
+        // window away mid-pan, and a live override would drag the world
+        // right back after it.
+        followMode.unfocus(pose.window)
+        if (pose.window && pose.window.client && pose.window.client.vr) {
+            KwinVrHelpers.setNodePositionFromScene(pose.window, pose.position)
+            KwinVrHelpers.setNodeRotationFromScene(pose.window, pose.rotation)
+        }
+    }
+
+    // Average distance from camera to every vr-floating window, excluding
+    // the target. Used as the depth target for the focus pull.
+    function _averageFloatingDistance(exclude) {
+        const camPos = root.camera.scenePosition
+        let total = 0.0
+        let count = 0
+        for (let i = 0; i < applicationWindowsRepeater.count; ++i) {
+            const w = applicationWindowsRepeater.objectAt(i)
+            if (!w || w === exclude) continue
+            if (!w.client || !w.client.vr || !w.visible) continue
+            if (w.stackedOnto) continue
+            total += w.scenePosition.minus(camPos).length()
+            count += 1
+        }
+        return count === 0 ? root.distance : total / count
+    }
+
+    // True if `w` participates in a dock/stack — those windows' poses belong
+    // to the snap manager, not the focus pull.
+    function _isSnapInvolved(w) {
+        if (w.stackedOnto)
+            return true
+        for (let i = 0; i < applicationWindowsRepeater.count; ++i) {
+            const other = applicationWindowsRepeater.objectAt(i)
+            if (other && other !== w && other.stackedOnto === w)
+                return true
+        }
+        return false
+    }
+
+    // Focus pull: slide the window along its cam→window direction to the
+    // sibling-average depth and re-face it to the user. Angular position in
+    // the user's surroundings is preserved (no teleport to center) — the
+    // world pan (followMode.focusOn) brings it the rest of the way.
+    function pullAppWinForward(appWin) {
+        if (!appWin || !appWin.client || !appWin.client.vr)
+            return
+        if (_isSnapInvolved(appWin))
+            return
+        if (_focusedPullPose && _focusedPullPose.window === appWin)
+            return
+        _restoreFocusedPullPose()
+
+        const camPos = root.camera.scenePosition
+        const windowPos = appWin.scenePosition
+        let dir = windowPos.minus(camPos)
+        const currentDist = dir.length()
+        if (currentDist < 0.0001)
+            return
+        dir = dir.times(1.0 / currentDist)
+
+        // Deep-copy the pose: scenePosition/sceneRotation are QML value-type
+        // *references* — stored raw they'd track the window through the pull
+        // and pan, making the restore a no-op.
+        const sceneRot = appWin.sceneRotation
+        _focusedPullPose = {
+            window: appWin,
+            position: Qt.vector3d(windowPos.x, windowPos.y, windowPos.z),
+            rotation: Qt.quaternion(sceneRot.scalar, sceneRot.x, sceneRot.y, sceneRot.z)
+        }
+
+        const newPos = camPos.plus(dir.times(_averageFloatingDistance(appWin)))
+        KwinVrHelpers.setNodePositionFromScene(appWin, newPos)
+        KwinVrHelpers.turnToFace(appWin, root.camera)
+
+        // Pan the world so the focused window ends up centered. Passes the
+        // camera explicitly because followMode.camera is null-gated during
+        // hover/grab/menu. No-op if already within the reactive FOV.
+        followMode.focusOn(appWin, root.camera)
+    }
+
+    // If the user grabs the focus-pulled window, grab becomes authoritative:
+    // drop the saved pose so defocus doesn't snap it back behind them.
+    Connections {
+        target: pickRay
+        function onGrabbedObjectChanged() {
+            if (root._focusedPullPose
+                && pickRay.grabbedObject === root._focusedPullPose.window) {
+                // The grab is authoritative over the pan too.
+                followMode.unfocus(root._focusedPullPose.window)
+                root._focusedPullPose = null
+            }
+        }
+    }
+
     Timer {
         id: autoAlignTimer
         onTriggered: allWindows.resetView()
@@ -647,6 +756,21 @@ Node {
                     Component.onCompleted: {
                         Qt.callLater(kwinAppWindow.registerForSpaceAllocator)
                         Qt.callLater(kwinAppWindow.maybeAutoFloat)
+                    }
+
+                    // Programmatic focus (taskbar click, alt+tab, scripts) —
+                    // pull a far-off floating window toward the user while
+                    // active, restore its prior pose when focus leaves.
+                    Connections {
+                        target: kwinAppWindow.client
+                        function onActiveChanged() {
+                            if (kwinAppWindow.client.active) {
+                                root.pullAppWinForward(kwinAppWindow)
+                            } else if (root._focusedPullPose
+                                       && root._focusedPullPose.window === kwinAppWindow) {
+                                root._restoreFocusedPullPose()
+                            }
+                        }
                     }
 
                     states: [

--- a/src/plugins/vr/vrfollowmode.cpp
+++ b/src/plugins/vr/vrfollowmode.cpp
@@ -202,9 +202,80 @@ void VrFollowMode::registerObject(QQuick3DNode *node)
 void VrFollowMode::unregisterObject(QQuick3DNode *node)
 {
     m_trackedNodes.removeAll(node);
+    if (node == m_focusOverride) {
+        clearFocusOverride();
+    }
     if (node) {
         disconnect(node, &QObject::destroyed, this, nullptr);
     }
+}
+
+void VrFollowMode::focusOn(QQuick3DNode *node, QQuick3DNode *camera)
+{
+    if (!node || !camera || !m_rotationTarget) {
+        return;
+    }
+    if (!node->visible()) {
+        return;
+    }
+
+    if (m_focusOverride && m_focusOverride != node) {
+        clearFocusOverride();
+    }
+    m_focusOverride = node;
+    m_focusCamera = camera;
+    // Dedicated connection handles: a blanket disconnect(node, ...) would
+    // also kill the tracked-node cleanup registerObject installed.
+    m_focusNodeDestroyed = connect(node, &QObject::destroyed, this, [this]() {
+        m_focusOverride = nullptr;
+        clearFocusOverride();
+    });
+    m_focusCameraDestroyed = connect(camera, &QObject::destroyed, this, [this]() {
+        m_focusCamera = nullptr;
+        clearFocusOverride();
+    });
+
+    // In-FOV test with the override camera in place (m_camera may be
+    // null-gated during hover/grab/menu). Already within the reactive
+    // FOV — consider it in-frame, nothing to pan.
+    const QVector2D angles = anglesToNode(node);
+    if (angles.x() <= m_fovH && angles.y() <= m_fovV) {
+        clearFocusOverride();
+        return;
+    }
+
+    // Make sure the frame loop is running — updateConnections would have
+    // stopped it when m_camera was null.
+    if (!m_frameTimer.isActive()) {
+        m_timer.start();
+        m_frameTimer.start();
+    }
+
+    m_lookAwayTime = 0.0;
+    setActive(true);
+}
+
+void VrFollowMode::unfocus(QQuick3DNode *node)
+{
+    if (node && node == m_focusOverride) {
+        clearFocusOverride();
+    }
+}
+
+void VrFollowMode::clearFocusOverride()
+{
+    disconnect(m_focusNodeDestroyed);
+    disconnect(m_focusCameraDestroyed);
+    m_focusOverride = nullptr;
+    m_focusCamera = nullptr;
+    // May need to stop the frame loop again if focusOn started it while
+    // the normal camera binding was null-gated.
+    updateConnections();
+}
+
+QQuick3DNode *VrFollowMode::effectiveCamera() const
+{
+    return (m_focusOverride && m_focusCamera) ? m_focusCamera : m_camera;
 }
 
 void VrFollowMode::updateConnections()
@@ -223,12 +294,13 @@ void VrFollowMode::updateConnections()
 
 QVector2D VrFollowMode::anglesToNode(const QQuick3DNode *node) const
 {
-    if (!m_camera || !node) {
+    QQuick3DNode *camera = effectiveCamera();
+    if (!camera || !node) {
         return QVector2D(180, 180);
     }
 
-    const QVector3D toNode = node->scenePosition() - m_camera->scenePosition();
-    const QVector3D localDir = m_camera->mapDirectionFromScene(toNode).normalized();
+    const QVector3D toNode = node->scenePosition() - camera->scenePosition();
+    const QVector3D localDir = camera->mapDirectionFromScene(toNode).normalized();
 
     const float hAngle = qAbs(qRadiansToDegrees(qAtan2(localDir.x(), -localDir.z())));
     const float vAngle = qAbs(qRadiansToDegrees(qAtan2(localDir.y(), -localDir.z())));
@@ -280,7 +352,10 @@ bool VrFollowMode::isNodeInStopFov(const QQuick3DNode *node) const
 
 void VrFollowMode::onFrame()
 {
-    if (!m_camera || !m_rotationTarget) {
+    // Effective camera: during a focus override, the explicit camera given
+    // to focusOn keeps the pan running even while the normal `camera`
+    // binding is null-gated (hover/grab/menu).
+    if (!effectiveCamera() || !m_rotationTarget) {
         return;
     }
 
@@ -288,17 +363,31 @@ void VrFollowMode::onFrame()
     m_timer.restart();
     const double dt = qMin(deltaTime, 0.1);
 
-    auto closest = findClosestNode();
-    if (!closest) {
+    // Override wins over closest while set — a focus-triggered pan must
+    // stay locked on its target until centered.
+    auto target = (m_focusOverride && m_focusOverride->visible())
+        ? m_focusOverride
+        : findClosestNode();
+    if (!target) {
         return;
     }
 
     if (m_active) {
-        if (isNodeInStopFov(closest)) {
+        if (isNodeInStopFov(target)) {
             setActive(false);
             m_lookAwayTime = 0.0;
+            if (m_focusOverride) {
+                // Final re-face: pan is done, lock orientation to cam.
+                KwinVrHelpers::turnToFace(m_focusOverride, effectiveCamera());
+                clearFocusOverride();
+            }
         } else {
-            rotateTowardsNode(closest, dt);
+            rotateTowardsNode(target, dt);
+            if (target == m_focusOverride) {
+                // Handle rotation drifts the override's scene rotation; re-face
+                // every frame so the window stays normal-to-camera with cam roll.
+                KwinVrHelpers::turnToFace(m_focusOverride, effectiveCamera());
+            }
         }
     } else {
         if (anyNodeInFov()) {
@@ -307,7 +396,7 @@ void VrFollowMode::onFrame()
             m_lookAwayTime += dt;
             if (m_lookAwayTime > m_delay) {
                 setActive(true);
-                rotateTowardsNode(closest, dt);
+                rotateTowardsNode(target, dt);
             }
         }
     }
@@ -315,14 +404,19 @@ void VrFollowMode::onFrame()
 
 void VrFollowMode::rotateTowardsNode(QQuick3DNode *node, double dt)
 {
+    QQuick3DNode *camera = effectiveCamera();
+    if (!camera) {
+        return;
+    }
+
     // Calculate rotation to bring node into view
-    QVector3D toClosest = node->scenePosition() - m_camera->scenePosition();
+    QVector3D toClosest = node->scenePosition() - camera->scenePosition();
     if (toClosest.lengthSquared() < 0.0001f) {
         return;
     }
 
     toClosest.normalize();
-    QVector3D cameraForward = m_camera->forward().normalized();
+    QVector3D cameraForward = camera->forward().normalized();
 
     // Delta rotation to bring the closest window into camera's forward direction
     QQuaternion deltaRotation = QQuaternion::rotationTo(toClosest, cameraForward);
@@ -332,7 +426,7 @@ void VrFollowMode::rotateTowardsNode(QQuick3DNode *node, double dt)
     QQuaternion currentSceneRot = m_rotationTarget->sceneRotation();
 
     // Pivot point is the camera position - we rotate around the user's head
-    QVector3D pivotPoint = m_camera->scenePosition();
+    QVector3D pivotPoint = camera->scenePosition();
 
     // Rotate position around pivot
     QVector3D offset = currentScenePos - pivotPoint;
@@ -346,7 +440,7 @@ void VrFollowMode::rotateTowardsNode(QQuick3DNode *node, double dt)
     QVector3D awayFromCamera = (targetScenePos - pivotPoint).normalized();
 
     // Reference rotation determines up vector for roll alignment
-    QQuaternion referenceRot = m_worldUpAlignment ? QQuaternion() : m_camera->sceneRotation();
+    QQuaternion referenceRot = m_worldUpAlignment ? QQuaternion() : camera->sceneRotation();
 
     // This makes -Z point away from camera, thus +Z points toward camera
     QQuaternion targetSceneRot = KwinVrHelpers::rotationToFaceDirection(awayFromCamera, referenceRot);

--- a/src/plugins/vr/vrfollowmode.h
+++ b/src/plugins/vr/vrfollowmode.h
@@ -74,6 +74,18 @@ public:
     Q_INVOKABLE void registerObject(QQuick3DNode *node);
     Q_INVOKABLE void unregisterObject(QQuick3DNode *node);
 
+    // Force-pan to center `node`. Takes an explicit camera (the normal
+    // `camera` binding gets null'd during hover/grab/menu, which would
+    // otherwise suppress the pan). The override stays locked on `node`
+    // until stop-FOV is reached, `node` is destroyed, or unfocus(node).
+    Q_INVOKABLE void focusOn(QQuick3DNode *node, QQuick3DNode *camera);
+
+    // Cancel an in-flight focusOn pan for `node`. No-op when `node` is not
+    // the current focus target. Needed when the caller moves the node away
+    // mid-pan (e.g. pose restore on defocus) — otherwise the override keeps
+    // dragging the world after it.
+    Q_INVOKABLE void unfocus(QQuick3DNode *node);
+
 Q_SIGNALS:
     void cameraChanged();
     void rotationTargetChanged();
@@ -89,6 +101,10 @@ Q_SIGNALS:
 private:
     void onFrame();
     void updateConnections();
+    // The camera FOV/pan math should use right now: the explicit focusOn
+    // camera while an override is active, the normal binding otherwise.
+    QQuick3DNode *effectiveCamera() const;
+    void clearFocusOverride();
     QVector2D anglesToNode(const QQuick3DNode *node) const;
     bool anyNodeInFov() const;
     QQuick3DNode *findClosestNode() const;
@@ -99,6 +115,15 @@ private:
     QQuick3DNode *m_camera = nullptr;
     QQuick3DNode *m_rotationTarget = nullptr;
     QList<QQuick3DNode *> m_trackedNodes;
+    // When set, onFrame pans toward this node instead of the angularly-closest
+    // tracked node. Cleared once the node reaches the stop-FOV.
+    QQuick3DNode *m_focusOverride = nullptr;
+    // Camera used while an override is active. Separate from m_camera so
+    // focus-pan works even when the main `camera` binding is gated null
+    // during hover/grab/menu interactions.
+    QQuick3DNode *m_focusCamera = nullptr;
+    QMetaObject::Connection m_focusNodeDestroyed;
+    QMetaObject::Connection m_focusCameraDestroyed;
     bool m_worldUpAlignment = true;
 
     int m_fovH = 50;


### PR DESCRIPTION
Salvages **feature 4 of #26** (archive commit `95947c85b6`): programmatic activation of a vr-floating window (taskbar, alt+tab, scripts) pulls it to a comfortable depth and pans the view to it; defocus puts it back.

## Behavior (new VOC-FOCUS section)
- **VOC-FOCUS-010**: on activation, save the window's pose, slide it along its camera→window ray to the sibling-average depth (`distance` if it's alone), face it to the user, and `focusOn()` pans the world until it's inside stop-FOV. Angular position is preserved — no teleport to center. Already-pulled and snap-involved windows are left alone.
- **VOC-FOCUS-020**: defocus cancels any in-flight pan and restores the saved pose (only while still vr-floating). Grabbing the pulled window drops the saved pose — manual placement wins.

## Fixes over the archive design
- `focusOn(node, camera)` takes an **explicit camera**: the followMode `camera` binding is null-gated during hover/grab/menu and whenever `followEnabled` is off — in the archive that killed the pan entirely. All FOV/pan math routes through `effectiveCamera()` so arrival detection works under the override.
- `unfocus(node)` cancels an in-flight pan; the pose restore calls it — otherwise a live override drags the world right back after the restored window (found by the replay test).
- Dedicated connection handles for the override's destroyed-hooks; the archive's blanket `disconnect` would have severed tracked-node cleanup → dangling pointers.
- QML pose save **deep-copies** scenePosition/sceneRotation — they're QML value-type references; stored raw, the "saved" pose tracks the window and the restore becomes a silent no-op (found by the replay test).

## Tests
- `kwinvr-testVrFollowMode` (new unit, 5 slots): pan into stop-FOV with null camera binding, no-op in FOV, destroy/unregister/unfocus teardown mid-pan.
- `kwinvr-testFlatFocusReplay` (new replay): three real Wayland clients drive **real activation edges**; boots `followEnabled=false` (new `VRTEST_EXTRA_CONFIG` harness hook) so the only possible pan source is `focusOn`'s explicit camera, and normal follow can't mask a broken restore.
- Full kwinvr suite 11/11 locally.

Docs: VOCABULARY.md (VOC-FOCUS-010/020 + status matrix), TEST_BASELINE.md row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)