### PR TITLE
vr: make the SBS auto-lease width gate configurable (autoLeaseMinWidth)

### DIFF
--- a/doc/VOCABULARY.md
+++ b/doc/VOCABULARY.md
@@ -779,9 +779,9 @@ Unverified where the key sequence's out-of-box availability matters.
 - Status: Working
 
 ### VOC-LIFECYCLE-060: Auto-lease configured outputs (SBS gate)
-**Given** `autoLeaseOutputs` non-empty **When** outputs are (re)enumerated, once per session **Then** each named output that supports leasing, is not non-desktop, **and is in SBS mode (mode width ≥ 3840)** is marked leasable; outputs not in SBS mode are skipped. After committing, leases are refreshed (VOC-LIFECYCLE-080).
+**Given** `autoLeaseOutputs` non-empty **When** outputs are (re)enumerated, once per session **Then** each named output that supports leasing, is not non-desktop, **and is in SBS mode (mode width ≥ `autoLeaseMinWidth`)** is marked leasable; outputs not in SBS mode are skipped (`autoLeaseMinWidth=0` disables the SBS check entirely). After committing, leases are refreshed (VOC-LIFECYCLE-080).
 - Input source(s): automatic (output hotplug)
-- Config keys: `autoLeaseOutputs ()`
+- Config keys: `autoLeaseOutputs ()`, `autoLeaseMinWidth (3840)`
 - Code: src/plugins/vr/kwinvr.cpp:437-494
 - Status: Working
 

--- a/src/plugins/vr/autotests/testvrconfig.cpp
+++ b/src/plugins/vr/autotests/testvrconfig.cpp
@@ -34,6 +34,8 @@ private Q_SLOTS:
         QCOMPARE(config.distance(), 100);
         QCOMPARE(config.hudEnabled(), false);
         QCOMPARE(config.followEnabled(), true);
+        // SBS auto-lease gate: 3840 = double-wide 1080p; 0 disables the check
+        QCOMPARE(config.autoLeaseMinWidth(), 3840);
     }
 
     void defaultValueGettersAgreeWithDefaults()

--- a/src/plugins/vr/kwinvr.cpp
+++ b/src/plugins/vr/kwinvr.cpp
@@ -533,11 +533,14 @@ void KwinVr::tryAutoLease()
             if (output->name() == name
                 && (output->capabilities() & BackendOutput::Capability::Leasing)
                 && !output->isNonDesktop()) {
-                // Only auto-lease when the display is in SBS mode (double-wide resolution)
+                // Only auto-lease when the display is in SBS mode (double-wide
+                // resolution). The threshold is configurable; 0 disables the check.
+                const int minWidth = config->autoLeaseMinWidth();
                 const int width = output->modeSize().width();
-                if (width < 3840) {
+                if (minWidth > 0 && width < minWidth) {
                     qCDebug(KWINVR) << "Auto-lease: skipping" << name
-                                    << "- not in SBS mode (width=" << width << ")";
+                                    << "- not in SBS mode (width=" << width
+                                    << "< autoLeaseMinWidth=" << minWidth << ")";
                     break;
                 }
                 anyConfigured = true;

--- a/src/plugins/vr/kwinvr.kcfg
+++ b/src/plugins/vr/kwinvr.kcfg
@@ -361,6 +361,10 @@
       <label>Output names to automatically lease on startup</label>
       <default></default>
     </entry>
+    <entry name="autoLeaseMinWidth" type="Int">
+      <label>Minimum mode width (px) treated as SBS for auto-lease; 0 disables the check</label>
+      <default>3840</default>
+    </entry>
     <entry name="autostartVr" type="Bool">
       <label>Automatically start VR mode after auto-leased outputs are leased</label>
       <default>false</default>


### PR DESCRIPTION
## Summary
- Replaces the hardcoded `width >= 3840` SBS heuristic in `KwinVr::tryAutoLease` with a new kcfg entry **`autoLeaseMinWidth`** (Int, default `3840`, group `[General]`): minimum mode width treated as SBS for auto-lease. Setting it to **0 disables the check** so any configured output leases regardless of its current mode.
- Skip debug message now reports both the observed width and the threshold.
- Default pinned in `testvrconfig.cpp` (`defaultsMatchKcfg`).
- VOC-LIFECYCLE-060 updated to cite the config key.

This is the configurable slice of the M3 roadmap line *"replace hardcoded ≥3840px SBS heuristic with EDID/configurable profiles"* — EDID/profile detection deliberately stays with the #23/#24 lease-robustness salvage.

## Test plan
- [x] `kwinvr-` ctest suite: 9/9 green locally (offscreen + dbus-run-session)
- [x] `kwinvr-testConfig` pins the new default
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)