### PR TITLE
vr: stale-socket detection for Monado activation (#23 custodian lesson)

### DIFF
--- a/doc/VOCABULARY.md
+++ b/doc/VOCABULARY.md
@@ -757,12 +757,12 @@ Unverified where the key sequence's out-of-box availability matters.
 - Code: src/plugins/vr/kwinvr.cpp:218-348
 - Status: Working
 
-### VOC-LIFECYCLE-030: Monado auto-start with socket poll
-**Given** the Monado IPC socket (`$XDG_RUNTIME_DIR/monado_comp_ipc`) is absent at activation **Then** `systemctl --user start monado.service` is spawned and the socket is polled every 500 ms; activation proceeds when it appears, or fails with a notification after 15 s.
+### VOC-LIFECYCLE-030: Monado auto-start with socket liveness poll
+**Given** the Monado IPC socket (`$XDG_RUNTIME_DIR/monado_comp_ipc`) is not **live** (no listener accepts a connection — a stale file left by a crashed Monado does not count, and is logged but never deleted: under systemd socket activation the connect itself starts the service) at activation **Then** `systemctl --user start monado.service` is spawned and the socket is connect-polled every 500 ms; activation proceeds when a connection is accepted, or fails with a notification after 15 s.
 - Input source(s): automatic
 - Config keys: none
-- Code: src/plugins/vr/kwinvr.cpp:168-216
-- Status: Working
+- Code: src/plugins/vr/kwinvr.cpp:171-235, src/plugins/vr/kwinvrhelpers.cpp (`isUnixSocketAlive`)
+- Status: Working (liveness check pinned by `kwinvr-testHelpers`; full path needs hardware)
 
 ### VOC-LIFECYCLE-040: VR exit restores the 2D session
 **When** VR deactivates (toggle off, XR failure, session end) **Then** the QML engine is destroyed and on destruction: `setVrMode(false)`, every window's `vr` flag cleared (all windows return to screens), dmabuf filter off, pointer limiter and popup resolver removed, `vrActive` notifies false. The virtual output is removed by its handle's destructor.

--- a/src/plugins/vr/CMakeLists.txt
+++ b/src/plugins/vr/CMakeLists.txt
@@ -26,6 +26,7 @@ ecm_qt_declare_logging_category(vr
 find_package(Qt6 REQUIRED COMPONENTS
     Core
     Gui GuiPrivate
+    Network
     Quick QuickPrivate
     Quick3D Quick3DPrivate
     Quick3DXr Quick3DXrPrivate)
@@ -156,6 +157,7 @@ target_link_libraries(vr
     Qt6::Core
     Qt6::Gui
     Qt6::GuiPrivate
+    Qt6::Network
     Qt6::Quick
     Qt6::QuickPrivate
     Qt6::Quick3D

--- a/src/plugins/vr/autotests/CMakeLists.txt
+++ b/src/plugins/vr/autotests/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(Qt6 REQUIRED COMPONENTS
     QuickTest
     Qml
     Gui GuiPrivate
+    Network
     Quick QuickPrivate
     Quick3D Quick3DPrivate
     Quick3DXr Quick3DXrPrivate)
@@ -48,6 +49,7 @@ target_link_libraries(testVrHelpers
     kwin
     Qt::Test
     Qt6::GuiPrivate
+    Qt6::Network
     Qt6::Quick
     Qt6::QuickPrivate
     Qt6::Quick3D

--- a/src/plugins/vr/autotests/testvrhelpers.cpp
+++ b/src/plugins/vr/autotests/testvrhelpers.cpp
@@ -6,9 +6,17 @@
 
 #include "../kwinvrhelpers.h"
 
+#include <QFile>
+#include <QFileInfo>
+#include <QLocalServer>
+#include <QTemporaryDir>
 #include <QTest>
 #include <QVector2D>
 #include <QVector3D>
+
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
 
 using namespace KWin;
 
@@ -178,6 +186,58 @@ private Q_SLOTS:
         const QString s = KwinVrHelpers::keyToString(Qt::Key_F, Qt::ControlModifier | Qt::ShiftModifier);
         QVERIFY(!s.isEmpty());
         QVERIFY(KwinVrHelpers::keyMatch(Qt::Key_F, Qt::ControlModifier | Qt::ShiftModifier, s));
+    }
+
+    // --- isUnixSocketAlive (#23 stale-socket detection) ---
+
+    void socketAliveWhenListenerAccepts()
+    {
+        QTemporaryDir dir;
+        QVERIFY(dir.isValid());
+        const QString path = dir.filePath(QStringLiteral("live.sock"));
+
+        QLocalServer server;
+        QVERIFY(server.listen(path));
+        QVERIFY(KwinVrHelpers::isUnixSocketAlive(path));
+    }
+
+    void socketStaleWhenFileHasNoListener()
+    {
+        // Simulate a crashed runtime: bind a unix socket, then close the fd
+        // without unlinking — the file survives but refuses connections.
+        QTemporaryDir dir;
+        QVERIFY(dir.isValid());
+        const QString path = dir.filePath(QStringLiteral("stale.sock"));
+
+        const int fd = ::socket(AF_UNIX, SOCK_STREAM, 0);
+        QVERIFY(fd >= 0);
+        sockaddr_un addr{};
+        addr.sun_family = AF_UNIX;
+        const QByteArray pathBytes = QFile::encodeName(path);
+        QVERIFY(pathBytes.size() < int(sizeof(addr.sun_path)));
+        ::memcpy(addr.sun_path, pathBytes.constData(), pathBytes.size() + 1);
+        QVERIFY(::bind(fd, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) == 0);
+        ::close(fd);
+
+        QVERIFY(QFileInfo::exists(path)); // the trap an existence check falls into
+        QVERIFY(!KwinVrHelpers::isUnixSocketAlive(path));
+    }
+
+    void socketStaleWhenPathIsPlainFile()
+    {
+        QTemporaryDir dir;
+        QVERIFY(dir.isValid());
+        const QString path = dir.filePath(QStringLiteral("not-a-socket"));
+        QFile file(path);
+        QVERIFY(file.open(QIODevice::WriteOnly));
+        file.close();
+
+        QVERIFY(!KwinVrHelpers::isUnixSocketAlive(path));
+    }
+
+    void socketStaleWhenPathMissing()
+    {
+        QVERIFY(!KwinVrHelpers::isUnixSocketAlive(QStringLiteral("/nonexistent/nowhere.sock")));
     }
 };
 

--- a/src/plugins/vr/kwinvr.cpp
+++ b/src/plugins/vr/kwinvr.cpp
@@ -170,13 +170,18 @@ bool KwinVr::initOpenXRLoaderWithRuntime(const QString &runtimeJsonPath, QString
 
 void KwinVr::ensureMonadoRunning()
 {
-    // Check if the OpenXR runtime's IPC socket exists.
-    // For Monado, this is monado_comp_ipc in XDG_RUNTIME_DIR.
+    // Check if the OpenXR runtime's IPC socket is live.
+    // For Monado, this is monado_comp_ipc in XDG_RUNTIME_DIR. A connect-test,
+    // not an existence check: a crashed Monado leaves the socket file behind,
+    // and proceeding against a stale socket fails deep in XR init (#23
+    // custodian lesson). The stale file is NOT removed — under systemd socket
+    // activation the connect itself starts the service, and deleting a
+    // socket-activated path breaks activation.
     const QString runtimeDir = QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation);
     const QString ipcSocket = runtimeDir + QStringLiteral("/monado_comp_ipc");
 
-    if (QFileInfo::exists(ipcSocket)) {
-        qCDebug(KWINVR) << "OpenXR runtime IPC socket found:" << ipcSocket;
+    if (KwinVrHelpers::isUnixSocketAlive(ipcSocket)) {
+        qCDebug(KWINVR) << "OpenXR runtime IPC socket is live:" << ipcSocket;
         proceedWithVrActivation();
         return;
     }
@@ -185,19 +190,24 @@ void KwinVr::ensureMonadoRunning()
         return; // Already waiting
     }
 
+    if (QFileInfo::exists(ipcSocket)) {
+        qCWarning(KWINVR) << "Stale OpenXR runtime IPC socket (exists but refuses connections):" << ipcSocket;
+    }
+
     qCDebug(KWINVR) << "OpenXR runtime not running, starting monado.service...";
 
     // Start the runtime via systemd user service (non-blocking)
     QProcess::startDetached(QStringLiteral("systemctl"),
                             {QStringLiteral("--user"), QStringLiteral("start"), QStringLiteral("monado.service")});
 
-    // Poll for the IPC socket to appear
+    // Poll for the IPC socket to come alive (liveness, not existence —
+    // a stale file must not satisfy the wait)
     m_waitingForMonado = true;
     auto *timer = new QTimer(this);
     int *attempts = new int(0);
     connect(timer, &QTimer::timeout, this, [this, timer, attempts, ipcSocket]() {
         (*attempts)++;
-        if (QFileInfo::exists(ipcSocket)) {
+        if (KwinVrHelpers::isUnixSocketAlive(ipcSocket)) {
             qCDebug(KWINVR) << "OpenXR runtime ready after" << *attempts * 500 << "ms";
             timer->stop();
             timer->deleteLater();
@@ -205,7 +215,10 @@ void KwinVr::ensureMonadoRunning()
             m_waitingForMonado = false;
             proceedWithVrActivation();
         } else if (*attempts >= 30) { // 15 seconds timeout
-            qCWarning(KWINVR) << "Timed out waiting for OpenXR runtime";
+            qCWarning(KWINVR) << "Timed out waiting for OpenXR runtime"
+                              << (QFileInfo::exists(ipcSocket)
+                                      ? "- socket file exists but never accepted a connection (stale?)"
+                                      : "- socket never appeared");
             timer->stop();
             timer->deleteLater();
             delete attempts;

--- a/src/plugins/vr/kwinvrhelpers.cpp
+++ b/src/plugins/vr/kwinvrhelpers.cpp
@@ -39,6 +39,7 @@
 #include "workspace.h"
 #include "xdgshellwindow.h"
 
+#include <QLocalSocket>
 #include <QQmlProperty>
 #include <QQuick3DObject>
 #include <QQuickItem>
@@ -146,6 +147,17 @@ QSizeF KwinVrHelpers::windowSize(Window *window)
         return QSizeF();
     }
     return window->frameGeometry().size();
+}
+
+bool KwinVrHelpers::isUnixSocketAlive(const QString &path, int timeoutMs)
+{
+    QLocalSocket socket;
+    socket.connectToServer(path);
+    if (!socket.waitForConnected(timeoutMs)) {
+        return false;
+    }
+    socket.disconnectFromServer();
+    return true;
 }
 
 bool KwinVrHelpers::keyMatch(int key, int modifiers, const QString &binding)

--- a/src/plugins/vr/kwinvrhelpers.h
+++ b/src/plugins/vr/kwinvrhelpers.h
@@ -87,6 +87,15 @@ public:
     Q_INVOKABLE void windowResize(Window *window, qreal dw, qreal dh);
     Q_INVOKABLE QSizeF windowSize(Window *window);
 
+    /**
+     * True when a unix socket at @p path has a live listener (a connect
+     * succeeds within @p timeoutMs). A socket file left behind by a crashed
+     * process exists but refuses connections — mere existence checks mistake
+     * it for a running service (#23 custodian lesson). A systemd
+     * socket-activated unit counts as alive: systemd accepts the connection.
+     */
+    Q_INVOKABLE static bool isUnixSocketAlive(const QString &path, int timeoutMs = 250);
+
     // Key helpers
     Q_INVOKABLE static bool keyMatch(int key, int modifiers, const QString &binding);
     Q_INVOKABLE static QString keyToString(int key, int modifiers);


### PR DESCRIPTION
## Summary
First slice of #23 (custodian lessons → current lease/startup path): **stale-socket detection**.

`ensureMonadoRunning` treated mere *existence* of `$XDG_RUNTIME_DIR/monado_comp_ipc` as "runtime ready". A socket file left behind by a crashed Monado exists but refuses connections, so activation sailed past the check and failed deep in XR init. The 500 ms poll had the same hole — a stale file satisfied the wait instantly even when `monado.service` failed to start.

- New `KwinVrHelpers::isUnixSocketAlive(path, timeoutMs=250)` — `QLocalSocket` connect-test.
- Both the fast path and the poll now require a live listener, not a file.
- The stale file is deliberately **NOT deleted** — the archived custodian's systemd lesson (`962f190382`) is that deleting a socket-activated path breaks activation; with socket activation the connect itself starts the service and correctly counts as alive. Stale files are logged.
- The 15 s timeout warning now distinguishes "socket never appeared" from "socket exists but never accepted a connection (stale?)".
- VOC-LIFECYCLE-030 updated to liveness semantics.

Remaining #23 scope (profile system, deactivation ordering) stays open — it overlaps the M4 runtime-profile design and needs owner input.

## Test plan
- [x] 4 new `kwinvr-testHelpers` slots: live listener accepts; bound-then-closed-without-unlink (the crash artifact — file exists, connect refused); plain file; missing path
- [x] Full `kwinvr-` suite 9/9 green locally
- [ ] CI green
- [ ] Hardware: crash Monado mid-session, reactivate VR — deferred to owner smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)