### PR TITLE
vr: re-arm auto-lease after replug, auto-exit VR on lease loss (M3)

### DIFF
--- a/doc/SMOKE.md
+++ b/doc/SMOKE.md
@@ -12,7 +12,8 @@ session unless an item says otherwise.
 ## 1. Lifecycle (≈2 min)
 - [ ] S1 — Glasses plugged in pre-login: session reaches the 3D workspace without manual DBus calls (VOC-LIFECYCLE: auto-lease + autostart)
 - [ ] S2 — `qdbus org.kde.kwinvr` exit/re-enter VR twice: no freeze, no black screen, windows return to their layout
-- [ ] S3 — Hot-unplug glasses while VR active: compositor survives, desktop usable on remaining outputs
+- [ ] S3 — Hot-unplug glasses while VR active: compositor survives, desktop usable on remaining outputs, **VR mode auto-exits** (lease-backed sessions only — manual flat-mode VR must NOT exit on output churn)
+- [ ] S3b — Replug glasses after S3 (and again after a clean exit): auto-lease + autostart run again — Monado restarts, lease lands, VR re-enters without any DBus/manual step. Repeat twice; the latch must re-arm every cycle
 
 ## 2. Gaze + cursor (≈1 min)
 - [ ] S4 — Head movement steers the cursor; small offsets via mouse work (VOC-GAZE: pointer offset)

--- a/src/plugins/vr/CMakeLists.txt
+++ b/src/plugins/vr/CMakeLists.txt
@@ -113,6 +113,7 @@ qt6_add_qml_module(vr
         geometrytypes.h
         zstacker.h zstacker.cpp
         spaceallocator3d.h spaceallocator3d.cpp
+        autoleasepolicy.h autoleasepolicy.cpp
         kwinvrbridge.h kwinvrbridge.cpp
         openxrtest.h openxrtest.cpp
         kwinvrinputdevice.h kwinvrinputdevice.cpp

--- a/src/plugins/vr/autoleasepolicy.cpp
+++ b/src/plugins/vr/autoleasepolicy.cpp
@@ -1,0 +1,72 @@
+/*
+    SPDX-FileCopyrightText: 2026 bake
+
+    SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+#include "autoleasepolicy.h"
+
+namespace KWin::AutoLeasePolicy
+{
+
+bool shouldRearm(const QStringList &configuredOutputs, const QList<OutputSnapshot> &outputs)
+{
+    if (configuredOutputs.isEmpty()) {
+        return false;
+    }
+    for (const OutputSnapshot &output : outputs) {
+        if (configuredOutputs.contains(output.name)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+QStringList eligibleOutputs(const QStringList &configuredOutputs, const QList<OutputSnapshot> &outputs, int minWidth)
+{
+    QStringList eligible;
+    for (const QString &name : configuredOutputs) {
+        for (const OutputSnapshot &output : outputs) {
+            if (output.name != name) {
+                continue;
+            }
+            if (!output.leasingCapable || output.nonDesktop) {
+                break;
+            }
+            // Only auto-lease when the display is in SBS mode (double-wide
+            // resolution) — the glasses expose plain 1920x1080 otherwise.
+            if (minWidth > 0 && output.width < minWidth) {
+                break;
+            }
+            eligible.append(name);
+            break;
+        }
+    }
+    return eligible;
+}
+
+bool anyLeased(const QList<OutputSnapshot> &outputs)
+{
+    for (const OutputSnapshot &output : outputs) {
+        if (output.leased) {
+            return true;
+        }
+    }
+    return false;
+}
+
+AutoStopAction autoStopAction(bool vrActive, bool sawLeaseWhileActive, const QList<OutputSnapshot> &outputs)
+{
+    if (!vrActive) {
+        return AutoStopAction::None;
+    }
+    if (anyLeased(outputs)) {
+        return AutoStopAction::RememberLease;
+    }
+    // Only lease-backed sessions auto-exit: a manually activated flat or
+    // no-lease session never saw a lease and must not be killed by output
+    // churn.
+    return sawLeaseWhileActive ? AutoStopAction::Stop : AutoStopAction::None;
+}
+
+} // namespace KWin::AutoLeasePolicy

--- a/src/plugins/vr/autoleasepolicy.h
+++ b/src/plugins/vr/autoleasepolicy.h
@@ -1,0 +1,56 @@
+/*
+    SPDX-FileCopyrightText: 2026 bake
+
+    SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+#pragma once
+
+#include <QList>
+#include <QString>
+#include <QStringList>
+
+namespace KWin
+{
+
+// Pure decision logic for the auto-lease / auto-start / auto-stop chain in
+// KwinVr (kwinvr.cpp). Kept free of backend types so the replug lifecycle —
+// which needs a physical hotplug on real hardware — can be pinned by a plain
+// unit test (autotests/testautoleasepolicy.cpp).
+namespace AutoLeasePolicy
+{
+
+// What the policy needs to know about one backend output.
+struct OutputSnapshot
+{
+    QString name;
+    bool leasingCapable = false;
+    bool nonDesktop = false;
+    bool leasable = false;
+    bool leased = false; // isLeased() || isLeasePending()
+    int width = 0; // current mode width (SBS gate)
+};
+
+// Replug re-arm: the auto-lease latch is one-shot per *connection*, not per
+// session. True when every configured output has disappeared from the
+// backend (glasses unplugged) — the caller then clears the latch so the next
+// hotplug runs the full lease+autostart chain again.
+bool shouldRearm(const QStringList &configuredOutputs, const QList<OutputSnapshot> &outputs);
+
+// Configured outputs that are present and eligible for auto-leasing right
+// now: lease-capable desktop outputs in SBS mode (width >= minWidth;
+// minWidth <= 0 disables the width check).
+QStringList eligibleOutputs(const QStringList &configuredOutputs, const QList<OutputSnapshot> &outputs, int minWidth);
+
+bool anyLeased(const QList<OutputSnapshot> &outputs);
+
+// Auto-stop transition for one output-change event.
+enum class AutoStopAction {
+    None, // nothing to do
+    RememberLease, // a lease is live while VR is active — mark the session lease-backed
+    Stop, // a lease-backed session lost its last lease — exit VR mode
+};
+AutoStopAction autoStopAction(bool vrActive, bool sawLeaseWhileActive, const QList<OutputSnapshot> &outputs);
+
+} // namespace AutoLeasePolicy
+} // namespace KWin

--- a/src/plugins/vr/autotests/CMakeLists.txt
+++ b/src/plugins/vr/autotests/CMakeLists.txt
@@ -30,6 +30,20 @@ target_link_libraries(testVrSpaceAllocator3D
 )
 add_test(NAME kwinvr-testSpaceAllocator3D COMMAND testVrSpaceAllocator3D)
 
+# --- auto-lease/auto-start/auto-stop policy (replug lifecycle) ---
+# Pure decision logic, no kwin link: pins the latch re-arm after unplug and
+# the lease-backed auto-stop gating that need a physical hotplug to exercise
+# end-to-end.
+add_executable(testVrAutoLeasePolicy
+    testautoleasepolicy.cpp
+    ../autoleasepolicy.cpp
+)
+target_include_directories(testVrAutoLeasePolicy PRIVATE ..)
+target_link_libraries(testVrAutoLeasePolicy
+    Qt::Test
+)
+add_test(NAME kwinvr-testAutoLeasePolicy COMMAND testVrAutoLeasePolicy)
+
 # --- helper math + key bindings (compiles the real kwinvrhelpers.cpp) ---
 add_executable(testVrHelpers
     testvrhelpers.cpp

--- a/src/plugins/vr/autotests/testautoleasepolicy.cpp
+++ b/src/plugins/vr/autotests/testautoleasepolicy.cpp
@@ -1,0 +1,191 @@
+/*
+    SPDX-FileCopyrightText: 2026 bake
+
+    SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+#include "autoleasepolicy.h"
+
+#include <QTest>
+
+using namespace KWin;
+using namespace KWin::AutoLeasePolicy;
+
+// Pins the auto-lease / auto-start / auto-stop decision logic, in particular
+// the replug lifecycle that can only be exercised end-to-end with a physical
+// hotplug: the one-shot latch must re-arm when the configured output
+// disappears, and a lease-backed VR session must stop when its last lease is
+// gone — while a manually activated no-lease session must never be touched.
+
+namespace
+{
+
+OutputSnapshot glassesSbs(bool leasable = false, bool leased = false)
+{
+    // Xreal Air on DP-2 in SBS mode (3840x1080)
+    return {
+        .name = QStringLiteral("DP-2"),
+        .leasingCapable = true,
+        .nonDesktop = false,
+        .leasable = leasable,
+        .leased = leased,
+        .width = 3840,
+    };
+}
+
+OutputSnapshot internalPanel()
+{
+    return {
+        .name = QStringLiteral("eDP-1"),
+        .leasingCapable = false,
+        .nonDesktop = false,
+        .leasable = false,
+        .leased = false,
+        .width = 1366,
+    };
+}
+
+const QStringList kConfigured{QStringLiteral("DP-2")};
+constexpr int kMinWidth = 3840;
+
+} // namespace
+
+class TestAutoLeasePolicy : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void eligibleRequiresPresence()
+    {
+        QVERIFY(eligibleOutputs(kConfigured, {internalPanel()}, kMinWidth).isEmpty());
+        QCOMPARE(eligibleOutputs(kConfigured, {internalPanel(), glassesSbs()}, kMinWidth),
+                 QStringList{QStringLiteral("DP-2")});
+    }
+
+    void eligibleRequiresLeasingCapability()
+    {
+        OutputSnapshot noLeaseCap = glassesSbs();
+        noLeaseCap.leasingCapable = false;
+        QVERIFY(eligibleOutputs(kConfigured, {noLeaseCap}, kMinWidth).isEmpty());
+    }
+
+    void eligibleRejectsNonDesktop()
+    {
+        OutputSnapshot nonDesktop = glassesSbs();
+        nonDesktop.nonDesktop = true;
+        QVERIFY(eligibleOutputs(kConfigured, {nonDesktop}, kMinWidth).isEmpty());
+    }
+
+    void eligibleGatesOnSbsWidth()
+    {
+        // Glasses in plain 1080p mirror mode must not be auto-leased
+        OutputSnapshot mirrorMode = glassesSbs();
+        mirrorMode.width = 1920;
+        QVERIFY(eligibleOutputs(kConfigured, {mirrorMode}, kMinWidth).isEmpty());
+        // minWidth <= 0 disables the gate
+        QCOMPARE(eligibleOutputs(kConfigured, {mirrorMode}, 0),
+                 QStringList{QStringLiteral("DP-2")});
+    }
+
+    void rearmOnlyWhenAllConfiguredGone()
+    {
+        // Output present (leased or not): keep the latch
+        QVERIFY(!shouldRearm(kConfigured, {internalPanel(), glassesSbs(true, true)}));
+        QVERIFY(!shouldRearm(kConfigured, {glassesSbs(true, false)}));
+        // Output gone (unplugged): re-arm
+        QVERIFY(shouldRearm(kConfigured, {internalPanel()}));
+        QVERIFY(shouldRearm(kConfigured, {}));
+        // No configuration: nothing to re-arm
+        QVERIFY(!shouldRearm({}, {internalPanel()}));
+    }
+
+    void autoStopIgnoresInactiveSession()
+    {
+        QCOMPARE(autoStopAction(false, false, {}), AutoStopAction::None);
+        QCOMPARE(autoStopAction(false, true, {}), AutoStopAction::None);
+    }
+
+    void autoStopMarksLeaseBackedSession()
+    {
+        QCOMPARE(autoStopAction(true, false, {glassesSbs(true, true)}),
+                 AutoStopAction::RememberLease);
+    }
+
+    void autoStopNeverKillsNoLeaseSession()
+    {
+        // Manually activated VR (flat mode, debugging) never saw a lease —
+        // output churn must not exit it.
+        QCOMPARE(autoStopAction(true, false, {internalPanel()}), AutoStopAction::None);
+        QCOMPARE(autoStopAction(true, false, {}), AutoStopAction::None);
+    }
+
+    void autoStopFiresWhenLeaseBackedSessionLosesLastLease()
+    {
+        QCOMPARE(autoStopAction(true, true, {internalPanel()}), AutoStopAction::Stop);
+        QCOMPARE(autoStopAction(true, true, {}), AutoStopAction::Stop);
+        // A surviving lease anywhere keeps the session alive
+        QCOMPARE(autoStopAction(true, true, {glassesSbs(true, true)}),
+                 AutoStopAction::RememberLease);
+    }
+
+    // The regression scenario verbatim: "drm and vr mode set to auto, works
+    // the first time. Looks like it won't lease again after a replug."
+    // Walks the policy functions in the exact order kwinvr.cpp's slots call
+    // them across plug → lease → VR active → unplug → replug.
+    void replugLifecycle()
+    {
+        bool triggered = false;
+        bool active = false;
+        bool sawLease = false;
+        int leaseCycles = 0;
+
+        // One outputsQueried/outputLeaseStateChanged event, mirroring the
+        // tryAutoLease + checkAutoStopVr slot logic.
+        auto onOutputsChanged = [&](const QList<OutputSnapshot> &outputs) {
+            if (triggered && shouldRearm(kConfigured, outputs)) {
+                triggered = false;
+            }
+            if (!triggered && !active
+                && !eligibleOutputs(kConfigured, outputs, kMinWidth).isEmpty()) {
+                triggered = true;
+                leaseCycles++; // refreshLeases: monado restart + lease offer
+            }
+            switch (autoStopAction(active, sawLease, outputs)) {
+            case AutoStopAction::RememberLease:
+                sawLease = true;
+                break;
+            case AutoStopAction::Stop:
+                sawLease = false;
+                active = false;
+                break;
+            case AutoStopAction::None:
+                break;
+            }
+        };
+
+        // First plug: glasses appear in SBS mode → lease cycle starts
+        onOutputsChanged({internalPanel(), glassesSbs()});
+        QCOMPARE(leaseCycles, 1);
+
+        // Monado takes the lease, VR auto-starts
+        onOutputsChanged({internalPanel(), glassesSbs(true, true)});
+        active = true;
+        onOutputsChanged({internalPanel(), glassesSbs(true, true)});
+        QVERIFY(sawLease);
+
+        // Unplug while active: output gone → VR exits, latch re-arms
+        onOutputsChanged({internalPanel()});
+        QVERIFY(!active);
+        QVERIFY(!triggered);
+        QCOMPARE(leaseCycles, 1);
+
+        // Replug: the full chain must run again (this was the bug — the
+        // one-shot latch blocked every lease after the first)
+        onOutputsChanged({internalPanel(), glassesSbs(true)});
+        QCOMPARE(leaseCycles, 2);
+        QVERIFY(triggered);
+    }
+};
+
+QTEST_GUILESS_MAIN(TestAutoLeasePolicy)
+#include "testautoleasepolicy.moc"

--- a/src/plugins/vr/kwinvr.cpp
+++ b/src/plugins/vr/kwinvr.cpp
@@ -6,6 +6,7 @@
 
 #include "kwinvr.h"
 
+#include "autoleasepolicy.h"
 #include "core/backendoutput.h"
 #include "core/outputbackend.h"
 #include "core/outputconfiguration.h"
@@ -57,6 +58,10 @@ KwinVr::KwinVr()
     // Auto-lease configured outputs once they become available
     connect(kwinApp()->outputBackend(), &OutputBackend::outputsQueried, this, &KwinVr::tryAutoLease);
     connect(kwinApp()->outputBackend(), &OutputBackend::outputLeaseStateChanged, this, &KwinVr::checkAutoStartVr);
+    // Auto-stop: a lease-backed VR session exits when its last lease is gone
+    // (glasses unplugged while in VR mode)
+    connect(kwinApp()->outputBackend(), &OutputBackend::outputsQueried, this, &KwinVr::checkAutoStopVr);
+    connect(kwinApp()->outputBackend(), &OutputBackend::outputLeaseStateChanged, this, &KwinVr::checkAutoStopVr);
     // Outputs may already be available if plugin loaded after initial enumeration
     QTimer::singleShot(0, this, &KwinVr::tryAutoLease);
 
@@ -252,11 +257,15 @@ void KwinVr::proceedWithVrActivation()
         workspace()->setPopupBoundsResolver(nullptr);
 
         m_active = false;
+        m_sawLeaseWhileActive = false;
         Q_EMIT vrActiveChanged();
     });
     // m_active will be set to false only when engine is deleted
     m_active = true;
     Q_EMIT vrActiveChanged();
+    // Seed the lease-backed marker: if a lease is already live at activation
+    // (the auto-start path), losing it later must exit VR mode.
+    checkAutoStopVr();
 
     if (!useFlatMode() && KWinVRConfigWrapper::instance()->xrTestEnabled()) {
         m_xrTest.start();
@@ -522,58 +531,68 @@ QString KwinVr::evalInWorkspace(const QString &expression)
     return undefined ? QStringLiteral("undefined") : result.toString();
 }
 
+static QList<AutoLeasePolicy::OutputSnapshot> snapshotOutputs()
+{
+    const auto outputs = kwinApp()->outputBackend()->outputs();
+    QList<AutoLeasePolicy::OutputSnapshot> snapshot;
+    snapshot.reserve(outputs.size());
+    for (BackendOutput *output : outputs) {
+        snapshot.append(AutoLeasePolicy::OutputSnapshot{
+            .name = output->name(),
+            .leasingCapable = bool(output->capabilities() & BackendOutput::Capability::Leasing),
+            .nonDesktop = output->isNonDesktop(),
+            .leasable = output->isLeasable(),
+            .leased = output->isLeased() || output->isLeasePending(),
+            .width = output->modeSize().width(),
+        });
+    }
+    return snapshot;
+}
+
 void KwinVr::tryAutoLease()
 {
-    if (m_autoLeaseTriggered || m_active) {
-        return;
-    }
-
     auto config = KWinVRConfigWrapper::instance();
     const QStringList autoOutputs = config->autoLeaseOutputs();
     if (autoOutputs.isEmpty()) {
         return;
     }
 
-    const auto outputs = kwinApp()->outputBackend()->outputs();
-    if (outputs.isEmpty()) {
+    const auto outputs = snapshotOutputs();
+
+    // The latch below is one-shot per *connection*, not per session: when
+    // every configured output has disappeared from the backend (glasses
+    // unplugged), re-arm so the next hotplug runs the full lease+autostart
+    // chain again instead of short-circuiting forever (#54).
+    if (m_autoLeaseTriggered && AutoLeasePolicy::shouldRearm(autoOutputs, outputs)) {
+        qCDebug(KWINVR) << "Auto-lease: configured outputs disconnected, re-arming for next hotplug";
+        m_autoLeaseTriggered = false;
+        m_autoStartPending = false;
+    }
+
+    if (m_autoLeaseTriggered || m_active) {
         return;
     }
 
-    bool anyConfigured = false;
+    // The width threshold gates on SBS mode; 0 disables the check.
+    const QStringList eligible = AutoLeasePolicy::eligibleOutputs(autoOutputs, outputs, config->autoLeaseMinWidth());
+    if (eligible.isEmpty()) {
+        qCDebug(KWINVR) << "Auto-lease: no outputs in SBS mode for:" << autoOutputs;
+        return;
+    }
 
-    for (const QString &name : autoOutputs) {
-        for (BackendOutput *output : outputs) {
-            if (output->name() == name
-                && (output->capabilities() & BackendOutput::Capability::Leasing)
-                && !output->isNonDesktop()) {
-                // Only auto-lease when the display is in SBS mode (double-wide
-                // resolution). The threshold is configurable; 0 disables the check.
-                const int minWidth = config->autoLeaseMinWidth();
-                const int width = output->modeSize().width();
-                if (minWidth > 0 && width < minWidth) {
-                    qCDebug(KWINVR) << "Auto-lease: skipping" << name
-                                    << "- not in SBS mode (width=" << width
-                                    << "< autoLeaseMinWidth=" << minWidth << ")";
-                    break;
-                }
-                anyConfigured = true;
-                if (!output->isLeasable()) {
-                    setOutputLeasable(name, true);
-                }
+    for (const QString &name : eligible) {
+        for (const AutoLeasePolicy::OutputSnapshot &output : outputs) {
+            if (output.name == name && !output.leasable) {
+                setOutputLeasable(name, true);
                 break;
             }
         }
     }
 
-    if (!anyConfigured) {
-        qCDebug(KWINVR) << "Auto-lease: no outputs in SBS mode for:" << autoOutputs;
-        return;
-    }
-
     // Only set the flag once we've actually committed to leasing
     m_autoLeaseTriggered = true;
 
-    qCDebug(KWINVR) << "Auto-lease: leasing configured outputs:" << autoOutputs;
+    qCDebug(KWINVR) << "Auto-lease: leasing configured outputs:" << eligible;
 
     if (config->autostartVr()) {
         m_autoStartPending = true;
@@ -601,13 +620,45 @@ void KwinVr::checkAutoStartVr()
                 m_autoStartPending = false;
                 // Give KWin time to finish output reconfiguration after lease grant
                 QTimer::singleShot(3000, this, [this] {
-                    if (!m_active) {
-                        setVrActive(true);
+                    if (m_active) {
+                        return;
                     }
+                    // The glasses may have been unplugged during the settle
+                    // delay — never start VR against a lease that is gone.
+                    if (!AutoLeasePolicy::anyLeased(snapshotOutputs())) {
+                        qCDebug(KWINVR) << "Auto-start: lease vanished during settle delay, aborting";
+                        return;
+                    }
+                    setVrActive(true);
                 });
                 return;
             }
         }
+    }
+}
+
+void KwinVr::checkAutoStopVr()
+{
+    using AutoLeasePolicy::AutoStopAction;
+    switch (AutoLeasePolicy::autoStopAction(m_active, m_sawLeaseWhileActive, snapshotOutputs())) {
+    case AutoStopAction::RememberLease:
+        // This session is lease-backed: only such sessions auto-exit on lease
+        // loss, so a manually activated flat/no-lease session is never killed.
+        m_sawLeaseWhileActive = true;
+        break;
+    case AutoStopAction::Stop: // #55: glasses unplugged while in VR mode
+        qCInfo(KWINVR) << "Auto-stop: no leased outputs remain, exiting VR mode";
+        m_sawLeaseWhileActive = false;
+        // Defer out of the signal handler — stop() tears down the QML engine
+        // and touches output state.
+        QTimer::singleShot(0, this, [this] {
+            if (m_active) {
+                setVrActive(false);
+            }
+        });
+        break;
+    case AutoStopAction::None:
+        break;
     }
 }
 

--- a/src/plugins/vr/kwinvr.h
+++ b/src/plugins/vr/kwinvr.h
@@ -61,11 +61,13 @@ private:
     void proceedWithVrActivation();
     void tryAutoLease();
     void checkAutoStartVr();
+    void checkAutoStopVr();
 
     bool m_active = false;
     bool m_waitingForMonado = false;
     bool m_autoLeaseTriggered = false;
     bool m_autoStartPending = false;
+    bool m_sawLeaseWhileActive = false;
     QQmlApplicationEngine *m_engine = nullptr;
     OpenXRTest m_xrTest;
     KConfigWatcher::Ptr m_watcher;


### PR DESCRIPTION
Fixes #54, fixes #55 — both halves of the 2026-06-12 field report:

> drm and vr mode set to auto, works the first time. Looks like it won't lease again after a replug. […] Also, when in vr mode, if no leased displays available, exit vr mode

## What

- **Replug re-lease (#54):** `m_autoLeaseTriggered` re-arms when every configured auto-lease output disappears from the backend — the latch is now one-shot per *connection*, not per session. Next hotplug runs the full lease + autostart chain (Monado restart included) again.
- **Auto-exit (#55):** a lease-backed VR session (one that observed a lease while active) exits VR when leases drop to zero. `sawLeaseWhileActive` gating means manual flat/no-lease sessions are never killed by output churn. Exit deferred out of the signal handler.
- **Settle-delay guard:** the 3s autostart delay re-checks the lease before `setVrActive(true)` — an unplug inside the window no longer starts VR against nothing.

## Regression armor

- Decision logic extracted to pure `autoleasepolicy.{h,cpp}` (no backend deps); new unit test `kwinvr-testAutoLeasePolicy` pins eligibility gates (SBS width, leasing capability, non-desktop), the re-arm condition, auto-stop gating, and a simulated full plug→lease→active→unplug→replug lifecycle.
- Smoke: S3 extended (auto-exit assertion) + new S3b (double replug cycle), since physical hotplug can't run in CI.

smoke: pending hardware pass on nipplepad (owner replug testing — the exact variants this PR exists for).

🤖 Generated with [Claude Code](https://claude.com/claude-code)